### PR TITLE
Mime Ideas

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,23 @@ A library for that maps mime types to extensions and vice-versa.
 
 ## Installation
 
-The package can be installed as:
+Add `mime` to your list of dependencies in `mix.exs`:
 
-  1. Add mime to your list of dependencies in `mix.exs`:
+```elixir
+def deps do
+  [{:mime, "~> 1.0.0"}]
+end
+```
 
-        def deps do
-          [{:mime, "~> 1.0"}]
-        end
+## Usage
 
-  2. Ensure mime is started before your application:
+Add any custom types you want in your `config/config.exs`:
 
-        def application do
-          [applications: [:mime]]
-        end
+```elixir
+config :mime, :types, %{
+  "application/vnd.api+json" => ["json-api"]
+}
+```
 
 ## License
 

--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -32,7 +32,14 @@ defmodule MIME do
     end
   end)
 
+  old = Application.get_env(:plug, :mimes, %{})
   app = Application.get_env(:mime, :types, %{})
+
+  unless Map.keys(old) == [] do
+    IO.write :stderr, "warning: `config :plug, :mimes` is deprecated, please use `config :mime, :types` instead\n"
+  end
+
+  app = Map.merge(old, app)
 
   mapping = Enum.reduce app, mapping, fn {k, v}, acc ->
     type = to_string(k)

--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -41,11 +41,30 @@ defmodule MIME do
 
   app = Map.merge(old, app)
 
-  mapping = Enum.reduce app, mapping, fn {k, v}, acc ->
+  @mapping Enum.reduce app, mapping, fn {k, v}, acc ->
     type = to_string(k)
     exts = Enum.map(List.wrap(v), &to_string/1)
     List.keystore(acc, type, 0, {type, exts})
   end
+      
+  
+  @doc """
+  Returns a Keyword list of MIME types and their associated extensions.
+  """
+  @spec mapping :: Keyword.t
+  def mapping, do: @mapping |> List.keysort(0)
+  
+  @doc """
+  Returns a list of all known MIME types.
+  """
+  @spec types :: list(String.t)
+  def types, do: @mapping |> Enum.map(&(elem(&1, 0))) |> Enum.sort
+  
+  @doc """
+  Returns a list of all known extensions associated with MIME types.
+  """
+  @spec extensions :: list(String.t)
+  def extensions, do: @mapping |> Enum.map(&(elem(&1, 1))) |> List.flatten |> Enum.uniq |> Enum.sort
 
   @doc """
   Returns whether a MIME type is registered.
@@ -130,9 +149,10 @@ defmodule MIME do
   # entry/1
   @spec entry(String.t) :: list(String.t)
 
-  for {type, exts} <- mapping do
+  for {type, exts} <- @mapping do
     defp entry(unquote(type)), do: unquote(exts)
   end
 
   defp entry(_type), do: nil
+      
 end

--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -35,7 +35,9 @@ defmodule MIME do
   app = Application.get_env(:mime, :types, %{})
 
   mapping = Enum.reduce app, mapping, fn {k, v}, acc ->
-    List.keystore(acc, k, 0, {k, v})
+    type = to_string(k)
+    exts = Enum.map(List.wrap(v), &to_string/1)
+    List.keystore(acc, type, 0, {type, exts})
   end
 
   @doc """

--- a/lib/mime.types
+++ b/lib/mime.types
@@ -1,5 +1,9 @@
 # https://git.fedorahosted.org/cgit/mailcap.git/plain/mime.types
 
+# Updated:                2016-04-28
+# Synced with IANA as of: 2016-04-17
+# Reference: https://git.fedorahosted.org/cgit/mailcap.git/commit/?id=c038c01832de3ea44945a2b26137313fd6263a77
+
 # This file controls what Internet media types are sent to the client for
 # given file extension(s).  Sending the correct media type to the client
 # is important so they know how to handle the content of the file.
@@ -10,11 +14,11 @@
 
 # IANA types
 
-# MIME type         Extensions
+# MIME type					Extensions
 application/1d-interleaved-parityfec
 application/3gpdash-qoe-report+xml
 application/3gpp-ims+xml
-application/A2L         a2l
+application/A2L					a2l
 application/activemessage
 application/alto-costmap+json
 application/alto-costmapfilter+json
@@ -26,88 +30,96 @@ application/alto-endpointpropparams+json
 application/alto-error+json
 application/alto-networkmap+json
 application/alto-networkmapfilter+json
-application/AML         aml
-application/andrew-inset      ez
+application/AML					aml
+application/andrew-inset			ez
 application/applefile
-application/ATF         atf
-application/ATFX        atfx
-application/ATXML       atxml
-application/atom+xml        atom
-application/atomcat+xml       atomcat
-application/atomdeleted+xml     atomdeleted
+application/ATF					atf
+application/ATFX				atfx
+application/ATXML				atxml
+application/atom+xml				atom
+application/atomcat+xml				atomcat
+application/atomdeleted+xml			atomdeleted
 application/atomicmail
-application/atomsvc+xml       atomsvc
-application/auth-policy+xml     apxml
-application/bacnet-xdd+zip      xdd
+application/atomsvc+xml				atomsvc
+application/auth-policy+xml			apxml
+application/bacnet-xdd+zip			xdd
 application/batch-SMTP
 application/beep+xml
 application/calendar+json
-application/calendar+xml      xcs
+application/calendar+xml			xcs
 application/call-completion
 application/cals-1840
-application/cbor        cbor
-application/ccmp+xml        ccmp
-application/ccxml+xml       ccxml
-application/CDFX+XML        cdfx
-application/cdmi-capability     cdmia
-application/cdmi-container      cdmic
-application/cdmi-domain       cdmid
-application/cdmi-object       cdmio
-application/cdmi-queue        cdmiq
-application/CEA         cea
+application/cbor				cbor
+application/ccmp+xml				ccmp
+application/ccxml+xml				ccxml
+application/CDFX+XML				cdfx
+application/cdmi-capability			cdmia
+application/cdmi-container			cdmic
+application/cdmi-domain				cdmid
+application/cdmi-object				cdmio
+application/cdmi-queue				cdmiq
+application/cdni
+application/CEA					cea
 application/cea-2018+xml
-application/cellml+xml        cellml cml
+application/cellml+xml				cellml cml
 application/cfw
-application/cms         cmsc
+application/cms					cmsc
 application/cnrp+xml
 application/coap-group+json
 application/commonground
 application/conference-info+xml
-application/cpl+xml       cpl
-application/csrattrs        csrattrs
+application/cpl+xml				cpl
+application/csrattrs				csrattrs
 application/csta+xml
 application/CSTAdata+xml
+application/csvm+json
 application/cybercash
-application/dash+xml        mpd
-application/dashdelta       mpdd
-application/davmount+xml      davmount
+application/dash+xml				mpd
+application/dashdelta				mpdd
+application/davmount+xml			davmount
 application/dca-rft
-application/DCD         dcd
+application/DCD					dcd
 application/dec-dx
 application/dialog-info+xml
-application/dicom       dcm
-application/DII         dii
-application/DIT         dit
+application/dicom				dcm
+application/DII					dii
+application/DIT					dit
 application/dns
-application/dskpp+xml       xmls
-application/dssc+der        dssc
-application/dssc+xml        xdssc
-application/dvcs        dvc
-application/ecmascript        es
+application/dskpp+xml				xmls
+application/dssc+der				dssc
+application/dssc+xml				xdssc
+application/dvcs				dvc
+application/ecmascript				es
 application/EDI-Consent
 application/EDI-X12
 application/EDIFACT
-application/emma+xml        emma
-application/emotionml+xml     emotionml
+application/efi					efi
+application/EmergencyCallData.Comment+xml
+application/EmergencyCallData.DeviceInfo+xml
+application/EmergencyCallData.ProviderInfo+xml
+application/EmergencyCallData.ServiceInfo+xml
+application/EmergencyCallData.SubscriberInfo+xml
+application/emma+xml				emma
+application/emotionml+xml			emotionml
 application/encaprtp
 application/epp+xml
-application/epub+zip        epub
+application/epub+zip				epub
 application/eshop
-application/exi         exi
-application/fastinfoset       finf
+application/exi					exi
+application/fastinfoset				finf
 application/fastsoap
-application/fdt+xml       fdt
+application/fdt+xml				fdt
 # fits, fit, fts: image/fits
 application/fits
-application/font-sfnt       ttf
-application/font-tdpfr        pfr
-application/font-woff       woff
+application/font-sfnt				ttf
+application/font-tdpfr				pfr
+application/font-woff				woff
 application/framework-attributes+xml
-application/gzip        gz tgz
+application/gzip				gz tgz
 application/H224
 application/held+xml
 application/http
-application/hyperstudio       stk
+application/hyperstudio				stk
 application/ibe-key-request+xml
 application/ibe-pkg-reply+xml
 application/ibe-pp-data
@@ -118,39 +130,39 @@ application/index.cmd
 application/index.obj
 application/index.response
 application/index.vnd
-application/inkml+xml       ink inkml
+application/inkml+xml				ink inkml
 application/iotp
-application/ipfix       ipfix
+application/ipfix				ipfix
 application/ipp
 application/isup
-application/its+xml       its
-application/javascript        js
+application/its+xml				its
+application/javascript				js
 application/jose
 application/jose+json
-application/jrd+json        jrd
-application/json        json
-application/json-patch+json     json-patch
+application/jrd+json				jrd
+application/json				json
+application/json-patch+json			json-patch
 application/json-seq
 application/jwk+json
 application/jwk-set+json
 application/jwt
 application/kpml-request+xml
 application/kpml-response+xml
-application/ld+json       jsonld
-application/link-format       wlnk
+application/ld+json				jsonld
+application/link-format				wlnk
 application/load-control+xml
-application/lost+xml        lostxml
-application/lostsync+xml      lostsyncxml
-application/LXF         lxf
-application/mac-binhex40      hqx
+application/lost+xml				lostxml
+application/lostsync+xml			lostsyncxml
+application/LXF					lxf
+application/mac-binhex40			hqx
 application/macwriteii
-application/mads+xml        mads
-application/marc        mrc
-application/marcxml+xml       mrcx
-application/mathematica       nb ma mb
+application/mads+xml				mads
+application/marc				mrc
+application/marcxml+xml				mrcx
+application/mathematica				nb ma mb
 application/mathml-content+xml
 application/mathml-presentation+xml
-application/mathml+xml        mml
+application/mathml+xml				mml
 application/mbms-associated-procedure-description+xml
 application/mbms-deregister+xml
 application/mbms-envelope+xml
@@ -162,22 +174,22 @@ application/mbms-register-response+xml
 application/mbms-register+xml
 application/mbms-schedule+xml
 application/mbms-user-service-description+xml
-application/mbox        mbox
+application/mbox				mbox
 application/media_control+xml
 # mpf: text/vnd.ms-mediapackage
 application/media-policy-dataset+xml
 application/mediaservercontrol+xml
 application/merge-patch+json
-application/metalink4+xml     meta4
-application/mets+xml        mets
-application/MF4         mf4
+application/metalink4+xml			meta4
+application/mets+xml				mets
+application/MF4					mf4
 application/mikey
-application/mods+xml        mods
+application/mods+xml				mods
 application/moss-keys
 application/moss-signature
 application/mosskey-data
 application/mosskey-request
-application/mp21        m21 mp21
+application/mp21				m21 mp21
 # mp4, mpg4: video/mp4, see RFC 4337
 application/mp4
 application/mpeg4-generic
@@ -188,84 +200,91 @@ application/mrb-consumer+xml
 application/mrb-publish+xml
 application/msc-ivr+xml
 application/msc-mixer+xml
-application/msword        doc
-application/mxf         mxf
+application/msword				doc
+application/mxf					mxf
 application/nasdata
 application/news-checkgroups
 application/news-groupinfo
 application/news-transmission
 application/nlsml+xml
 application/nss
-application/ocsp-request      orq
-application/ocsp-response     ors
-application/octet-stream    bin lha lzh exe class so dll img iso
-application/oda         oda
-application/ODX         odx
-application/oebps-package+xml     opf
-application/ogg         ogx
-application/oxps        oxps
-application/p2p-overlay+xml     relo
+application/ocsp-request			orq
+application/ocsp-response			ors
+application/octet-stream		bin lha lzh exe class so dll img iso
+application/oda					oda
+application/ODX					odx
+application/oebps-package+xml			opf
+application/ogg					ogx
+application/oxps				oxps
+application/p2p-overlay+xml			relo
 application/parityfec
 # xer: application/xcap-error+xml
 application/patch-ops-error+xml
-application/pdf         pdf
-application/PDX         pdx
-application/pgp-encrypted     pgp
+application/pdf					pdf
+application/PDX					pdx
+application/pgp-encrypted			pgp
 application/pgp-keys
-application/pgp-signature     sig
+application/pgp-signature			sig
 application/pidf-diff+xml
 application/pidf+xml
-application/pkcs10        p10
-application/pkcs7-mime        p7m p7c
-application/pkcs7-signature     p7s
-application/pkcs8       p8
+application/pkcs10				p10
+application/pkcs12				p12 pfx
+application/pkcs7-mime				p7m p7c
+application/pkcs7-signature			p7s
+application/pkcs8				p8
 # ac: application/vnd.nokia.n-gage.ac+xml
 application/pkix-attr-cert
-application/pkix-cert       cer
-application/pkix-crl        crl
-application/pkix-pkipath      pkipath
-application/pkixcmp       pki
-application/pls+xml       pls
+application/pkix-cert				cer
+application/pkix-crl				crl
+application/pkix-pkipath			pkipath
+application/pkixcmp				pki
+application/pls+xml				pls
 application/poc-settings+xml
-application/postscript        ps eps ai
-application/provenance+xml      provx
+application/postscript				ps eps ai
+application/ppsp-tracker+json
+application/problem+json
+application/problem+xml
+application/provenance+xml			provx
 application/prs.alvestrand.titrax-sheet
-application/prs.cww       cw cww
-application/prs.hpub+zip      hpub
-application/prs.nprend        rnd rct
+application/prs.cww				cw cww
+application/prs.hpub+zip			hpub
+application/prs.nprend				rnd rct
 application/prs.plucker
-application/prs.rdf-xml-crypt     rdf-crypt
-application/prs.xsf+xml       xsf
-application/pskc+xml        pskcxml
+application/prs.rdf-xml-crypt			rdf-crypt
+application/prs.xsf+xml				xsf
+application/pskc+xml				pskcxml
 application/qsig
 application/raptorfec
 application/rdap+json
-application/rdf+xml       rdf
-application/reginfo+xml       rif
-application/relax-ng-compact-syntax   rnc
+application/rdf+xml				rdf
+application/reginfo+xml				rif
+application/relax-ng-compact-syntax		rnc
 application/remote-printing
 application/reputon+json
-application/resource-lists-diff+xml   rld
-application/resource-lists+xml      rl
+application/resource-lists-diff+xml		rld
+application/resource-lists+xml			rl
+application/rfc+xml				rfcxml
 application/riscos
 application/rlmi+xml
-application/rls-services+xml      rs
-application/rpki-ghostbusters     gbr
-application/rpki-manifest     mft
-application/rpki-roa        roa
+application/rls-services+xml			rs
+application/rpki-ghostbusters			gbr
+application/rpki-manifest			mft
+application/rpki-roa				roa
 application/rpki-updown
-application/rtf         rtf
+application/rtf					rtf
 application/rtploopback
 application/rtx
 application/samlassertion+xml
 application/samlmetadata+xml
 application/sbml+xml
 application/scaip+xml
-application/scvp-cv-request     scq
-application/scvp-cv-response      scs
-application/scvp-vp-request     spq
-application/scvp-vp-response      spp
-application/sdp         sdp
+# scm: application/vnd.lotus-screencam
+application/scim+json				scim
+application/scvp-cv-request			scq
+application/scvp-cv-response			scs
+application/scvp-vp-request			spq
+application/scvp-vp-response			spp
+application/sdp					sdp
 application/sep+xml
 application/sep-exi
 application/session-info
@@ -274,171 +293,186 @@ application/set-payment-initiation
 application/set-registration
 application/set-registration-initiation
 application/sgml
-application/sgml-open-catalog     soc
-application/shf+xml       shf
-application/sieve       siv sieve
-application/simple-filter+xml     cl
+application/sgml-open-catalog			soc
+application/shf+xml				shf
+application/sieve				siv sieve
+application/simple-filter+xml			cl
 application/simple-message-summary
 application/simpleSymbolContainer
 application/slate
 # application/smil obsoleted by application/smil+xml
-application/smil+xml        smil smi sml
+application/smil+xml				smil smi sml
 application/smpte336m
 application/soap+fastinfoset
 application/soap+xml
-application/sparql-query      rq
-application/sparql-results+xml      srx
+application/sparql-query			rq
+application/sparql-results+xml			srx
 application/spirits-event+xml
-application/sql         sql
-application/srgs        gram
-application/srgs+xml        grxml
-application/sru+xml       sru
-application/ssml+xml        ssml
-application/tamp-apex-update      tau
-application/tamp-apex-update-confirm    auc
-application/tamp-community-update   tcu
-application/tamp-community-update-confirm cuc
-application/tamp-error        ter
-application/tamp-sequence-adjust    tsa
-application/tamp-sequence-adjust-confirm  sac
+application/sql					sql
+application/srgs				gram
+application/srgs+xml				grxml
+application/sru+xml				sru
+application/ssml+xml				ssml
+application/tamp-apex-update			tau
+application/tamp-apex-update-confirm		auc
+application/tamp-community-update		tcu
+application/tamp-community-update-confirm	cuc
+application/tamp-error				ter
+application/tamp-sequence-adjust		tsa
+application/tamp-sequence-adjust-confirm	sac
 # tsq: application/timestamp-query
 application/tamp-status-query
 # tsr: application/timestamp-reply
 application/tamp-status-response
-application/tamp-update       tur
-application/tamp-update-confirm     tuc
-application/tei+xml       tei teiCorpus odd
-application/thraud+xml        tfi
-application/timestamp-query     tsq
-application/timestamp-reply     tsr
-application/timestamped-data      tsd
-application/ttml+xml        ttml
+application/tamp-update				tur
+application/tamp-update-confirm			tuc
+application/tei+xml				tei teiCorpus odd
+application/thraud+xml				tfi
+application/timestamp-query			tsq
+application/timestamp-reply			tsr
+application/timestamped-data			tsd
+application/ttml+xml				ttml
 application/tve-trigger
 application/ulpfec
-application/urc-grpsheet+xml      gsheet
-application/urc-ressheet+xml      rsheet
-application/urc-targetdesc+xml      td
-application/urc-uisocketdesc+xml    uis
+application/urc-grpsheet+xml			gsheet
+application/urc-ressheet+xml			rsheet
+application/urc-targetdesc+xml			td
+application/urc-uisocketdesc+xml		uis
 application/vcard+json
 application/vcard+xml
 application/vemmi
+application/vnd.3gpp.access-transfer-events+xml
 application/vnd.3gpp.bsf+xml
-application/vnd.3gpp.pic-bw-large   plb
-application/vnd.3gpp.pic-bw-small   psb
-application/vnd.3gpp.pic-bw-var     pvb
+application/vnd.3gpp.mid-call+xml
+application/vnd.3gpp.pic-bw-large		plb
+application/vnd.3gpp.pic-bw-small		psb
+application/vnd.3gpp.pic-bw-var			pvb
+application/vnd.3gpp-prose+xml
+application/vnd.3gpp-prose-pc3ch+xml
 # sms: application/vnd.3gpp2.sms
 application/vnd.3gpp.sms
+application/vnd.3gpp.sms+xml
+application/vnd.3gpp.srvcc-ext+xml
+application/vnd.3gpp.SRVCC-info+xml
+application/vnd.3gpp.state-and-event-info+xml
+application/vnd.3gpp.ussd+xml
 application/vnd.3gpp2.bcmcsinfo+xml
-application/vnd.3gpp2.sms     sms
-application/vnd.3gpp2.tcap      tcap
-application/vnd.3M.Post-it-Notes    pwn
-application/vnd.accpac.simply.aso   aso
-application/vnd.accpac.simply.imp   imp
-application/vnd.acucobol      acu
-application/vnd.acucorp       atc acutc
+application/vnd.3gpp2.sms			sms
+application/vnd.3gpp2.tcap			tcap
+application/vnd.3lightssoftware.imagescal	imgcal
+application/vnd.3M.Post-it-Notes		pwn
+application/vnd.accpac.simply.aso		aso
+application/vnd.accpac.simply.imp		imp
+application/vnd.acucobol			acu
+application/vnd.acucorp				atc acutc
 # swf: application/x-shockwave-flash for now
 application/vnd.adobe.flash.movie
-application/vnd.adobe.formscentral.fcdt   fcdt
-application/vnd.adobe.fxp     fxp fxpl
+application/vnd.adobe.formscentral.fcdt		fcdt
+application/vnd.adobe.fxp			fxp fxpl
 application/vnd.adobe.partial-upload
-application/vnd.adobe.xdp+xml     xdp
-application/vnd.adobe.xfdf      xfdf
+application/vnd.adobe.xdp+xml			xdp
+application/vnd.adobe.xfdf			xfdf
 application/vnd.aether.imp
 application/vnd.ah-barcode
-application/vnd.ahead.space     ahead
-application/vnd.airzip.filesecure.azf   azf
-application/vnd.airzip.filesecure.azs   azs
-application/vnd.americandynamics.acc    acc
-application/vnd.amiga.ami     ami
+application/vnd.ahead.space			ahead
+application/vnd.airzip.filesecure.azf		azf
+application/vnd.airzip.filesecure.azs		azs
+application/vnd.americandynamics.acc		acc
+application/vnd.amiga.ami			ami
 application/vnd.amundsen.maze+xml
-application/vnd.anser-web-certificate-issue-initiation  cii
+application/vnd.anki				apkg
+application/vnd.anser-web-certificate-issue-initiation	cii
 # Not in IANA listing, but is on FTP site?
-application/vnd.anser-web-funds-transfer-initiation fti
+application/vnd.anser-web-funds-transfer-initiation	fti
 # atx: audio/ATRAC-X
 application/vnd.antix.game-component
 application/vnd.apache.thrift.binary
 application/vnd.apache.thrift.compact
 application/vnd.apache.thrift.json
 application/vnd.api+json
-application/vnd.apple.installer+xml   dist distz pkg mpkg
+application/vnd.apple.installer+xml		dist distz pkg mpkg
 # m3u: audio/x-mpegurl for now
-application/vnd.apple.mpegurl     m3u8
+application/vnd.apple.mpegurl			m3u8
 # application/vnd.arastra.swi obsoleted by application/vnd.aristanetworks.swi
-application/vnd.aristanetworks.swi    swi
+application/vnd.aristanetworks.swi		swi
 application/vnd.artsquare
-application/vnd.astraea-software.iota   iota
-application/vnd.audiograph      aep
-application/vnd.autopackage     package
+application/vnd.astraea-software.iota		iota
+application/vnd.audiograph			aep
+application/vnd.autopackage			package
 application/vnd.avistar+xml
-application/vnd.balsamiq.bmml+xml   bmml
+application/vnd.balsamiq.bmml+xml		bmml
+application/vnd.balsamiq.bmpr			bmpr
 application/vnd.bekitzur-stech+json
-application/vnd.blueice.multipass   mpm
-application/vnd.bluetooth.ep.oob    ep
-application/vnd.bluetooth.le.oob    le
-application/vnd.bmi       bmi
-application/vnd.businessobjects     rep
+application/vnd.biopax.rdf+xml
+application/vnd.blueice.multipass		mpm
+application/vnd.bluetooth.ep.oob		ep
+application/vnd.bluetooth.le.oob		le
+application/vnd.bmi				bmi
+application/vnd.businessobjects			rep
 application/vnd.cab-jscript
 application/vnd.canon-cpdl
 application/vnd.canon-lips
-application/vnd.cendio.thinlinc.clientconf  tlclient
+application/vnd.cendio.thinlinc.clientconf	tlclient
 application/vnd.century-systems.tcp_stream
-application/vnd.chemdraw+xml      cdxml
-application/vnd.chipnuts.karaoke-mmd    mmd
-application/vnd.cinderella      cdy
+application/vnd.chemdraw+xml			cdxml
+application/vnd.chipnuts.karaoke-mmd		mmd
+application/vnd.cinderella			cdy
 application/vnd.cirpack.isdn-ext
-application/vnd.citationstyles.style+xml  csl
-application/vnd.claymore      cla
-application/vnd.cloanto.rp9     rp9
-application/vnd.clonk.c4group     c4g c4d c4f c4p c4u
-application/vnd.cluetrust.cartomobile-config  c11amc
-application/vnd.cluetrust.cartomobile-config-pkg  c11amz
-application/vnd.coffeescript      coffee
+application/vnd.citationstyles.style+xml	csl
+application/vnd.claymore			cla
+application/vnd.cloanto.rp9			rp9
+application/vnd.clonk.c4group			c4g c4d c4f c4p c4u
+application/vnd.cluetrust.cartomobile-config	c11amc
+application/vnd.cluetrust.cartomobile-config-pkg	c11amz
+application/vnd.coffeescript			coffee
 application/vnd.collection+json
 application/vnd.collection.doc+json
 application/vnd.collection.next+json
 # icc: application/vnd.iccprofile
-application/vnd.commerce-battelle ica icf icd ic0 ic1 ic2 ic3 ic4 ic5 ic6 ic7 ic8
-application/vnd.commonspace     csp cst
-application/vnd.contact.cmsg      cdbcmsg
-application/vnd.cosmocaller     cmc
-application/vnd.crick.clicker     clkx
-application/vnd.crick.clicker.keyboard    clkk
-application/vnd.crick.clicker.palette   clkp
-application/vnd.crick.clicker.template    clkt
-application/vnd.crick.clicker.wordbank    clkw
-application/vnd.criticaltools.wbs+xml   wbs
-application/vnd.ctc-posml     pml
+application/vnd.commerce-battelle	ica icf icd ic0 ic1 ic2 ic3 ic4 ic5 ic6 ic7 ic8
+application/vnd.commonspace			csp cst
+application/vnd.contact.cmsg			cdbcmsg
+application/vnd.coreos.ignition+json		ign ignition
+application/vnd.cosmocaller			cmc
+application/vnd.crick.clicker			clkx
+application/vnd.crick.clicker.keyboard		clkk
+application/vnd.crick.clicker.palette		clkp
+application/vnd.crick.clicker.template		clkt
+application/vnd.crick.clicker.wordbank		clkw
+application/vnd.criticaltools.wbs+xml		wbs
+application/vnd.ctc-posml			pml
 application/vnd.ctct.ws+xml
 application/vnd.cups-pdf
 application/vnd.cups-postscript
-application/vnd.cups-ppd      ppd
+application/vnd.cups-ppd			ppd
 application/vnd.cups-raster
 application/vnd.cups-raw
-application/vnd.curl        curl
+application/vnd.curl				curl
 application/vnd.cyan.dean.root+xml
 application/vnd.cybank
-application/vnd.dart        dart
-application/vnd.data-vision.rdz     rdz
-application/vnd.debian.binary-package   deb udeb
-application/vnd.dece.data     uvf uvvf uvd uvvd
-application/vnd.dece.ttml+xml     uvt uvvt
-application/vnd.dece.unspecified    uvx uvvx
-application/vnd.dece.zip      uvz uvvz
-application/vnd.denovo.fcselayout-link    fe_launch
-application/vnd.desmume.movie     dsm
+application/vnd.dart				dart
+application/vnd.data-vision.rdz			rdz
+application/vnd.debian.binary-package		deb udeb
+application/vnd.dece.data			uvf uvvf uvd uvvd
+application/vnd.dece.ttml+xml			uvt uvvt
+application/vnd.dece.unspecified		uvx uvvx
+application/vnd.dece.zip			uvz uvvz
+application/vnd.denovo.fcselayout-link		fe_launch
+application/vnd.desmume.movie			dsm
 application/vnd.dir-bi.plate-dl-nosuffix
 application/vnd.dm.delegation+xml
-application/vnd.dna       dna
-application/vnd.document+json     docjson
+application/vnd.dna				dna
+application/vnd.document+json			docjson
 application/vnd.dolby.mobile.1
 application/vnd.dolby.mobile.2
-application/vnd.doremir.scorecloud-binary-document  scld
-application/vnd.dpgraph       dpg mwc dpgraph
-application/vnd.dreamfactory      dfac
+application/vnd.doremir.scorecloud-binary-document	scld
+application/vnd.dpgraph				dpg mwc dpgraph
+application/vnd.dreamfactory			dfac
+application/vnd.drive+json
 application/vnd.dtg.local
-application/vnd.dtg.local.flash     fla
+application/vnd.dtg.local.flash			fla
 application/vnd.dtg.local.html
-application/vnd.dvb.ait       ait
+application/vnd.dvb.ait				ait
 # class: application/octet-stream
 application/vnd.dvb.dvbj
 application/vnd.dvb.esgcontainer
@@ -458,33 +492,33 @@ application/vnd.dvb.notif-ia-registration-response+xml
 application/vnd.dvb.notif-init+xml
 # pfr: application/font-tdpfr
 application/vnd.dvb.pfr
-application/vnd.dvb.service     svc
+application/vnd.dvb.service			svc
 # dxr: application/x-director
 application/vnd.dxr
-application/vnd.dynageo       geo
-application/vnd.dzr       dzr
+application/vnd.dynageo				geo
+application/vnd.dzr				dzr
 application/vnd.easykaraoke.cdgdownload
 application/vnd.ecdis-update
-application/vnd.ecowin.chart      mag
+application/vnd.ecowin.chart			mag
 application/vnd.ecowin.filerequest
 application/vnd.ecowin.fileupdate
 application/vnd.ecowin.series
 application/vnd.ecowin.seriesrequest
 application/vnd.ecowin.seriesupdate
-application/vnd.enliven       nml
+application/vnd.enliven				nml
 application/vnd.enphase.envoy
 application/vnd.eprints.data+xml
-application/vnd.epson.esf     esf
-application/vnd.epson.msf     msf
-application/vnd.epson.quickanime    qam
-application/vnd.epson.salt      slt
-application/vnd.epson.ssf     ssf
-application/vnd.ericsson.quickcall    qcall qca
-application/vnd.eszigno3+xml      es3 et3
+application/vnd.epson.esf			esf
+application/vnd.epson.msf			msf
+application/vnd.epson.quickanime		qam
+application/vnd.epson.salt			slt
+application/vnd.epson.ssf			ssf
+application/vnd.ericsson.quickcall		qcall qca
+application/vnd.eszigno3+xml			es3 et3
 application/vnd.etsi.aoc+xml
-application/vnd.etsi.asic-e+zip     asice sce
+application/vnd.etsi.asic-e+zip			asice sce
 # scs: application/scvp-cv-response
-application/vnd.etsi.asic-s+zip     asics
+application/vnd.etsi.asic-s+zip			asics
 application/vnd.etsi.cug+xml
 application/vnd.etsi.iptvcommand+xml
 application/vnd.etsi.iptvdiscovery+xml
@@ -501,98 +535,102 @@ application/vnd.etsi.overload-control-policy-dataset+xml
 application/vnd.etsi.pstn+xml
 application/vnd.etsi.sci+xml
 application/vnd.etsi.simservs+xml
-application/vnd.etsi.timestamp-token    tst
+application/vnd.etsi.timestamp-token		tst
 application/vnd.etsi.tsl.der
 application/vnd.etsi.tsl+xml
 application/vnd.eudora.data
-application/vnd.ezpix-album     ez2
-application/vnd.ezpix-package     ez3
+application/vnd.ezpix-album			ez2
+application/vnd.ezpix-package			ez3
 application/vnd.f-secure.mobile
-application/vnd.fastcopy-disk-image   dim
-application/vnd.fdf       fdf
-application/vnd.fdsn.mseed      msd mseed
-application/vnd.fdsn.seed     seed dataless
+application/vnd.fastcopy-disk-image		dim
+application/vnd.fdf				fdf
+application/vnd.fdsn.mseed			msd mseed
+application/vnd.fdsn.seed			seed dataless
 application/vnd.ffsns
+application/vnd.filmit.zfc			zfc
 # all extensions: application/vnd.hbci
 application/vnd.fints
-application/vnd.FloGraphIt      gph
-application/vnd.fluxtime.clip     ftc
-application/vnd.font-fontforge-sfd    sfd
-application/vnd.framemaker      fm
-application/vnd.frogans.fnc     fnc
-application/vnd.frogans.ltf     ltf
-application/vnd.fsc.weblaunch     fsc
-application/vnd.fujitsu.oasys     oas
-application/vnd.fujitsu.oasys2      oa2
-application/vnd.fujitsu.oasys3      oa3
-application/vnd.fujitsu.oasysgp     fg5
-application/vnd.fujitsu.oasysprs    bh2
+application/vnd.firemonkeys.cloudcell
+application/vnd.FloGraphIt			gph
+application/vnd.fluxtime.clip			ftc
+application/vnd.font-fontforge-sfd		sfd
+application/vnd.framemaker			fm
+application/vnd.frogans.fnc			fnc
+application/vnd.frogans.ltf			ltf
+application/vnd.fsc.weblaunch			fsc
+application/vnd.fujitsu.oasys			oas
+application/vnd.fujitsu.oasys2			oa2
+application/vnd.fujitsu.oasys3			oa3
+application/vnd.fujitsu.oasysgp			fg5
+application/vnd.fujitsu.oasysprs		bh2
 application/vnd.fujixerox.ART-EX
 application/vnd.fujixerox.ART4
-application/vnd.fujixerox.ddd     ddd
-application/vnd.fujixerox.docuworks   xdw
-application/vnd.fujixerox.docuworks.binder  xbd
-application/vnd.fujixerox.docuworks.container xct
+application/vnd.fujixerox.ddd			ddd
+application/vnd.fujixerox.docuworks		xdw
+application/vnd.fujixerox.docuworks.binder	xbd
+application/vnd.fujixerox.docuworks.container	xct
 application/vnd.fujixerox.HBPL
 application/vnd.fut-misnet
-application/vnd.fuzzysheet      fzs
-application/vnd.genomatix.tuxedo    txd
-application/vnd.geo+json      geojson
-application/vnd.geocube+xml     g3 g³
-application/vnd.geogebra.file     ggb
-application/vnd.geogebra.tool     ggt
-application/vnd.geometry-explorer   gex gre
-application/vnd.geonext       gxt
-application/vnd.geoplan       g2w
-application/vnd.geospace      g3w
+application/vnd.fuzzysheet			fzs
+application/vnd.genomatix.tuxedo		txd
+application/vnd.geo+json			geojson
+application/vnd.geocube+xml			g3 g³
+application/vnd.geogebra.file			ggb
+application/vnd.geogebra.tool			ggt
+application/vnd.geometry-explorer		gex gre
+application/vnd.geonext				gxt
+application/vnd.geoplan				g2w
+application/vnd.geospace			g3w
 # gbr: application/rpki-ghostbusters
 application/vnd.gerber
 application/vnd.globalplatform.card-content-mgt
 application/vnd.globalplatform.card-content-mgt-response
-application/vnd.gmx       gmx
-application/vnd.google-earth.kml+xml    kml
-application/vnd.google-earth.kmz    kmz
+application/vnd.gmx				gmx
+application/vnd.google-earth.kml+xml		kml
+application/vnd.google-earth.kmz		kmz
 application/vnd.gov.sk.e-form+xml
 application/vnd.gov.sk.e-form+zip
 application/vnd.gov.sk.xmldatacontainer+xml
-application/vnd.grafeq        gqf gqs
+application/vnd.grafeq				gqf gqs
 application/vnd.gridmp
-application/vnd.groove-account      gac
-application/vnd.groove-help     ghf
-application/vnd.groove-identity-message   gim
-application/vnd.groove-injector     grv
-application/vnd.groove-tool-message   gtm
-application/vnd.groove-tool-template    tpl
-application/vnd.groove-vcard      vcg
+application/vnd.groove-account			gac
+application/vnd.groove-help			ghf
+application/vnd.groove-identity-message		gim
+application/vnd.groove-injector			grv
+application/vnd.groove-tool-message		gtm
+application/vnd.groove-tool-template		tpl
+application/vnd.groove-vcard			vcg
 application/vnd.hal+json
-application/vnd.hal+xml       hal
-application/vnd.HandHeld-Entertainment+xml  zmm
-application/vnd.hbci        hbci hbc kom upa pkd bpd
+application/vnd.hal+xml				hal
+application/vnd.HandHeld-Entertainment+xml	zmm
+application/vnd.hbci				hbci hbc kom upa pkd bpd
 # rep: application/vnd.businessobjects
 application/vnd.hcl-bireports
+application/vnd.hdt				hdt
 application/vnd.heroku+json
-application/vnd.hhe.lesson-player   les
-application/vnd.hp-HPGL       hpgl
-application/vnd.hp-hpid       hpi hpid
-application/vnd.hp-hps        hps
-application/vnd.hp-jlyt       jlt
-application/vnd.hp-PCL        pcl
+application/vnd.hhe.lesson-player		les
+application/vnd.hp-HPGL				hpgl
+application/vnd.hp-hpid				hpi hpid
+application/vnd.hp-hps				hps
+application/vnd.hp-jlyt				jlt
+application/vnd.hp-PCL				pcl
 application/vnd.hp-PCLXL
 application/vnd.httphone
-application/vnd.hydrostatix.sof-data    sfd-hdstx
-application/vnd.hzn-3d-crossword    x3d
+application/vnd.hydrostatix.sof-data		sfd-hdstx
+application/vnd.hyperdrive+json
+application/vnd.hzn-3d-crossword		x3d
 application/vnd.ibm.afplinedata
-application/vnd.ibm.electronic-media    emm
-application/vnd.ibm.MiniPay     mpy
-application/vnd.ibm.modcap      list3820 listafp afp pseg3820
-application/vnd.ibm.rights-management   irm
-application/vnd.ibm.secure-container    sc
-application/vnd.iccprofile      icc icm
-application/vnd.ieee.1905     1905.1
-application/vnd.igloader      igl
-application/vnd.immervision-ivp     ivp
-application/vnd.immervision-ivu     ivu
-application/vnd.ims.imsccv1p1     imscc
+application/vnd.ibm.electronic-media		emm
+application/vnd.ibm.MiniPay			mpy
+application/vnd.ibm.modcap			list3820 listafp afp pseg3820
+application/vnd.ibm.rights-management		irm
+application/vnd.ibm.secure-container		sc
+application/vnd.iccprofile			icc icm
+application/vnd.ieee.1905			1905.1
+application/vnd.igloader			igl
+application/vnd.immervision-ivp			ivp
+application/vnd.immervision-ivu			ivu
+application/vnd.ims.imsccv1p1			imscc
 application/vnd.ims.imsccv1p2
 application/vnd.ims.imsccv1p3
 application/vnd.ims.lis.v2.result+json
@@ -606,13 +644,13 @@ application/vnd.informedcontrol.rms+xml
 application/vnd.infotech.project
 application/vnd.infotech.project+xml
 application/vnd.innopath.wamp.notification
-application/vnd.insors.igm      igm
-application/vnd.intercon.formnet    xpw xpx
-application/vnd.intergeo      i2g
+application/vnd.insors.igm			igm
+application/vnd.intercon.formnet		xpw xpx
+application/vnd.intergeo			i2g
 application/vnd.intertrust.digibox
 application/vnd.intertrust.nncp
-application/vnd.intu.qbo      qbo
-application/vnd.intu.qfx      qfx
+application/vnd.intu.qbo			qbo
+application/vnd.intu.qfx			qfx
 application/vnd.iptc.g2.catalogitem+xml
 application/vnd.iptc.g2.conceptitem+xml
 application/vnd.iptc.g2.knowledgeitem+xml
@@ -620,11 +658,11 @@ application/vnd.iptc.g2.newsitem+xml
 application/vnd.iptc.g2.newsmessage+xml
 application/vnd.iptc.g2.packageitem+xml
 application/vnd.iptc.g2.planningitem+xml
-application/vnd.ipunplugged.rcprofile   rcprofile
-application/vnd.irepository.package+xml   irp
-application/vnd.is-xpr        xpr
-application/vnd.isac.fcs      fcs
-application/vnd.jam       jam
+application/vnd.ipunplugged.rcprofile		rcprofile
+application/vnd.irepository.package+xml		irp
+application/vnd.is-xpr				xpr
+application/vnd.isac.fcs			fcs
+application/vnd.jam				jam
 application/vnd.japannet-directory-service
 application/vnd.japannet-jpnstore-wakeup
 application/vnd.japannet-payment-wakeup
@@ -633,63 +671,66 @@ application/vnd.japannet-registration-wakeup
 application/vnd.japannet-setstore-wakeup
 application/vnd.japannet-verification
 application/vnd.japannet-verification-wakeup
-application/vnd.jcp.javame.midlet-rms   rms
-application/vnd.jisp        jisp
-application/vnd.joost.joda-archive    joda
+application/vnd.jcp.javame.midlet-rms		rms
+application/vnd.jisp				jisp
+application/vnd.joost.joda-archive		joda
 application/vnd.jsk.isdn-ngn
-application/vnd.kahootz       ktz ktr
-application/vnd.kde.karbon      karbon
-application/vnd.kde.kchart      chrt
-application/vnd.kde.kformula      kfo
-application/vnd.kde.kivio     flw
-application/vnd.kde.kontour     kon
-application/vnd.kde.kpresenter      kpr kpt
-application/vnd.kde.kspread     ksp
-application/vnd.kde.kword     kwd kwt
-application/vnd.kenameaapp      htke
-application/vnd.kidspiration      kia
-application/vnd.Kinar       kne knp sdf
-application/vnd.koan        skp skd skm skt
-application/vnd.kodak-descriptor    sse
-application/vnd.las.las+xml     lasxml
+application/vnd.kahootz				ktz ktr
+application/vnd.kde.karbon			karbon
+application/vnd.kde.kchart			chrt
+application/vnd.kde.kformula			kfo
+application/vnd.kde.kivio			flw
+application/vnd.kde.kontour			kon
+application/vnd.kde.kpresenter			kpr kpt
+application/vnd.kde.kspread			ksp
+application/vnd.kde.kword			kwd kwt
+application/vnd.kenameaapp			htke
+application/vnd.kidspiration			kia
+application/vnd.Kinar				kne knp sdf
+application/vnd.koan				skp skd skm skt
+application/vnd.kodak-descriptor		sse
+application/vnd.las.las+xml			lasxml
 application/vnd.liberty-request+xml
-application/vnd.llamagraphics.life-balance.desktop  lbd
-application/vnd.llamagraphics.life-balance.exchange+xml lbe
-application/vnd.lotus-1-2-3     123 wk4 wk3 wk1
-application/vnd.lotus-approach      apr vew
-application/vnd.lotus-freelance     prz pre
-application/vnd.lotus-notes     nsf ntf ndl ns4 ns3 ns2 nsh nsg
-application/vnd.lotus-organizer     or3 or2 org
-application/vnd.lotus-screencam     scm
-application/vnd.lotus-wordpro     lwp sam
-application/vnd.macports.portpkg    portpkg
+application/vnd.llamagraphics.life-balance.desktop	lbd
+application/vnd.llamagraphics.life-balance.exchange+xml	lbe
+application/vnd.lotus-1-2-3			123 wk4 wk3 wk1
+application/vnd.lotus-approach			apr vew
+application/vnd.lotus-freelance			prz pre
+application/vnd.lotus-notes			nsf ntf ndl ns4 ns3 ns2 nsh nsg
+application/vnd.lotus-organizer			or3 or2 org
+application/vnd.lotus-screencam			scm
+application/vnd.lotus-wordpro			lwp sam
+application/vnd.macports.portpkg		portpkg
+application/vnd.mapbox-vector-tile		mvt
 application/vnd.marlin.drm.actiontoken+xml
 application/vnd.marlin.drm.conftoken+xml
 application/vnd.marlin.drm.license+xml
-application/vnd.marlin.drm.mdcf     mdc
+application/vnd.marlin.drm.mdcf			mdc
 application/vnd.mason+json
-application/vnd.maxmind.maxmind-db    mmdb
-application/vnd.mcd       mcd
-application/vnd.medcalcdata     mc1
-application/vnd.mediastation.cdkey    cdkey
+application/vnd.maxmind.maxmind-db		mmdb
+application/vnd.mcd				mcd
+application/vnd.medcalcdata			mc1
+application/vnd.mediastation.cdkey		cdkey
 application/vnd.meridian-slingshot
-application/vnd.MFER        mwf
-application/vnd.mfmp        mfm
-application/vnd.micrografx.flo      flo
-application/vnd.micrografx.igx      igx
+application/vnd.MFER				mwf
+application/vnd.mfmp				mfm
+application/vnd.micro+json
+application/vnd.micrografx.flo			flo
+application/vnd.micrografx.igx			igx
+application/vnd.microsoft.portable-executable
 application/vnd.miele+json
-application/vnd.mif       mif
+application/vnd.mif				mif
 application/vnd.minisoft-hp3000-save
 application/vnd.mitsubishi.misty-guard.trustweb
-application/vnd.Mobius.DAF      daf
-application/vnd.Mobius.DIS      dis
-application/vnd.Mobius.MBK      mbk
-application/vnd.Mobius.MQY      mqy
-application/vnd.Mobius.MSL      msl
-application/vnd.Mobius.PLC      plc
-application/vnd.Mobius.TXF      txf
-application/vnd.mophun.application    mpn
-application/vnd.mophun.certificate    mpc
+application/vnd.Mobius.DAF			daf
+application/vnd.Mobius.DIS			dis
+application/vnd.Mobius.MBK			mbk
+application/vnd.Mobius.MQY			mqy
+application/vnd.Mobius.MSL			msl
+application/vnd.Mobius.PLC			plc
+application/vnd.Mobius.TXF			txf
+application/vnd.mophun.application		mpn
+application/vnd.mophun.certificate		mpc
 application/vnd.motorola.flexsuite
 application/vnd.motorola.flexsuite.adsi
 application/vnd.motorola.flexsuite.fis
@@ -698,62 +739,67 @@ application/vnd.motorola.flexsuite.kmr
 application/vnd.motorola.flexsuite.ttc
 application/vnd.motorola.flexsuite.wem
 application/vnd.motorola.iprm
-application/vnd.mozilla.xul+xml     xul
-application/vnd.ms-3mfdocument      3mf
-application/vnd.ms-artgalry     cil
-application/vnd.ms-asf        asf
-application/vnd.ms-cab-compressed   cab
-application/vnd.ms-excel      xls xlm xla xlc xlt xlw
-application/vnd.ms-excel.template.macroEnabled.12 xltm
-application/vnd.ms-excel.addin.macroEnabled.12  xlam
-application/vnd.ms-excel.sheet.binary.macroEnabled.12 xlsb
-application/vnd.ms-excel.sheet.macroEnabled.12  xlsm
-application/vnd.ms-fontobject     eot
-application/vnd.ms-htmlhelp     chm
-application/vnd.ms-ims        ims
-application/vnd.ms-lrm        lrm
+application/vnd.mozilla.xul+xml			xul
+application/vnd.ms-3mfdocument			3mf
+application/vnd.ms-artgalry			cil
+application/vnd.ms-asf				asf
+application/vnd.ms-cab-compressed		cab
+application/vnd.ms-excel			xls xlm xla xlc xlt xlw
+application/vnd.ms-excel.template.macroEnabled.12	xltm
+application/vnd.ms-excel.addin.macroEnabled.12	xlam
+application/vnd.ms-excel.sheet.binary.macroEnabled.12	xlsb
+application/vnd.ms-excel.sheet.macroEnabled.12	xlsm
+application/vnd.ms-fontobject			eot
+application/vnd.ms-htmlhelp			chm
+application/vnd.ms-ims				ims
+application/vnd.ms-lrm				lrm
 application/vnd.ms-office.activeX+xml
-application/vnd.ms-officetheme      thmx
+application/vnd.ms-officetheme			thmx
 application/vnd.ms-playready.initiator+xml
-application/vnd.ms-powerpoint     ppt pps pot
-application/vnd.ms-powerpoint.addin.macroEnabled.12 ppam
-application/vnd.ms-powerpoint.presentation.macroEnabled.12  pptm
-application/vnd.ms-powerpoint.slide.macroEnabled.12 sldm
-application/vnd.ms-powerpoint.slideshow.macroEnabled.12 ppsm
-application/vnd.ms-powerpoint.template.macroEnabled.12  potm
-application/vnd.ms-project      mpp mpt
-application/vnd.ms-tnef       tnef tnf
+application/vnd.ms-powerpoint			ppt pps pot
+application/vnd.ms-powerpoint.addin.macroEnabled.12	ppam
+application/vnd.ms-powerpoint.presentation.macroEnabled.12	pptm
+application/vnd.ms-powerpoint.slide.macroEnabled.12	sldm
+application/vnd.ms-powerpoint.slideshow.macroEnabled.12	ppsm
+application/vnd.ms-powerpoint.template.macroEnabled.12	potm
+application/vnd.ms-PrintDeviceCapabilities+xml
+application/vnd.ms-PrintSchemaTicket+xml
+application/vnd.ms-project			mpp mpt
+application/vnd.ms-tnef				tnef tnf
+application/vnd.ms-windows.devicepairing
+application/vnd.ms-windows.nwprinting.oob
 application/vnd.ms-windows.printerpairing
+application/vnd.ms-windows.wsd.oob
 application/vnd.ms-wmdrm.lic-chlg-req
 application/vnd.ms-wmdrm.lic-resp
 application/vnd.ms-wmdrm.meter-chlg-req
 application/vnd.ms-wmdrm.meter-resp
-application/vnd.ms-word.document.macroEnabled.12  docm
-application/vnd.ms-word.template.macroEnabled.12  dotm
-application/vnd.ms-works      wcm wdb wks wps
-application/vnd.ms-wpl        wpl
-application/vnd.ms-xpsdocument      xps
-application/vnd.msa-disk-image      msa
-application/vnd.mseq        mseq
+application/vnd.ms-word.document.macroEnabled.12	docm
+application/vnd.ms-word.template.macroEnabled.12	dotm
+application/vnd.ms-works			wcm wdb wks wps
+application/vnd.ms-wpl				wpl
+application/vnd.ms-xpsdocument			xps
+application/vnd.msa-disk-image			msa
+application/vnd.mseq				mseq
 application/vnd.msign
-application/vnd.multiad.creator     crtr
-application/vnd.multiad.creator.cif   cif
+application/vnd.multiad.creator			crtr
+application/vnd.multiad.creator.cif		cif
 application/vnd.music-niff
-application/vnd.musician      mus
-application/vnd.muvee.style     msty
-application/vnd.mynfc       taglet
+application/vnd.musician			mus
+application/vnd.muvee.style			msty
+application/vnd.mynfc				taglet
 application/vnd.ncd.control
 application/vnd.ncd.reference
-application/vnd.nervana       entity request bkm kcm
+application/vnd.nervana				entity request bkm kcm
 application/vnd.netfpx
 # ntf: application/vnd.lotus-notes
-application/vnd.nitf        nitf
-application/vnd.neurolanguage.nlu   nlu
-application/vnd.nintendo.nitro.rom    nds
-application/vnd.nintendo.snes.rom   sfc smc
-application/vnd.noblenet-directory    nnd
-application/vnd.noblenet-sealer     nns
-application/vnd.noblenet-web      nnw
+application/vnd.nitf				nitf
+application/vnd.neurolanguage.nlu		nlu
+application/vnd.nintendo.nitro.rom		nds
+application/vnd.nintendo.snes.rom		sfc smc
+application/vnd.noblenet-directory		nnd
+application/vnd.noblenet-sealer			nns
+application/vnd.noblenet-web			nnw
 application/vnd.nokia.catalogs
 application/vnd.nokia.conml+wbxml
 application/vnd.nokia.conml+xml
@@ -762,39 +808,39 @@ application/vnd.nokia.iSDS-radio-presets
 application/vnd.nokia.landmark+wbxml
 application/vnd.nokia.landmark+xml
 application/vnd.nokia.landmarkcollection+xml
-application/vnd.nokia.n-gage.ac+xml   ac
-application/vnd.nokia.n-gage.data   ngdat
-application/vnd.nokia.n-gage.symbian.install  n-gage
+application/vnd.nokia.n-gage.ac+xml		ac
+application/vnd.nokia.n-gage.data		ngdat
+application/vnd.nokia.n-gage.symbian.install	n-gage
 application/vnd.nokia.ncd
 application/vnd.nokia.pcd+wbxml
 application/vnd.nokia.pcd+xml
-application/vnd.nokia.radio-preset    rpst
-application/vnd.nokia.radio-presets   rpss
-application/vnd.novadigm.EDM      edm
-application/vnd.novadigm.EDX      edx
-application/vnd.novadigm.EXT      ext
+application/vnd.nokia.radio-preset		rpst
+application/vnd.nokia.radio-presets		rpss
+application/vnd.novadigm.EDM			edm
+application/vnd.novadigm.EDX			edx
+application/vnd.novadigm.EXT			ext
 application/vnd.ntt-local.content-share
 application/vnd.ntt-local.file-transfer
 application/vnd.ntt-local.ogw_remote-access
 application/vnd.ntt-local.sip-ta_remote
 application/vnd.ntt-local.sip-ta_tcp_stream
-application/vnd.oasis.opendocument.chart      odc
-application/vnd.oasis.opendocument.chart-template   otc
-application/vnd.oasis.opendocument.database     odb
-application/vnd.oasis.opendocument.formula      odf
-application/vnd.oasis.opendocument.formula-template   otf
-application/vnd.oasis.opendocument.graphics     odg
-application/vnd.oasis.opendocument.graphics-template    otg
-application/vnd.oasis.opendocument.image      odi
-application/vnd.oasis.opendocument.image-template   oti
-application/vnd.oasis.opendocument.presentation     odp
-application/vnd.oasis.opendocument.presentation-template  otp
-application/vnd.oasis.opendocument.spreadsheet      ods
-application/vnd.oasis.opendocument.spreadsheet-template   ots
-application/vnd.oasis.opendocument.text       odt
-application/vnd.oasis.opendocument.text-master      odm
-application/vnd.oasis.opendocument.text-template    ott
-application/vnd.oasis.opendocument.text-web     oth
+application/vnd.oasis.opendocument.chart			odc
+application/vnd.oasis.opendocument.chart-template		otc
+application/vnd.oasis.opendocument.database			odb
+application/vnd.oasis.opendocument.formula			odf
+application/vnd.oasis.opendocument.formula-template		otf
+application/vnd.oasis.opendocument.graphics			odg
+application/vnd.oasis.opendocument.graphics-template		otg
+application/vnd.oasis.opendocument.image			odi
+application/vnd.oasis.opendocument.image-template		oti
+application/vnd.oasis.opendocument.presentation			odp
+application/vnd.oasis.opendocument.presentation-template	otp
+application/vnd.oasis.opendocument.spreadsheet			ods
+application/vnd.oasis.opendocument.spreadsheet-template		ots
+application/vnd.oasis.opendocument.text				odt
+application/vnd.oasis.opendocument.text-master			odm
+application/vnd.oasis.opendocument.text-template		ott
+application/vnd.oasis.opendocument.text-web			oth
 application/vnd.obn
 application/vnd.oftn.l10n+json
 application/vnd.oipf.contentaccessdownload+xml
@@ -807,7 +853,7 @@ application/vnd.oipf.pae.gem
 application/vnd.oipf.spdiscovery+xml
 application/vnd.oipf.spdlist+xml
 application/vnd.oipf.ueprofile+xml
-application/vnd.olpc-sugar      xo
+application/vnd.olpc-sugar			xo
 application/vnd.oma.bcast.associated-procedure-parameter+xml
 application/vnd.oma.bcast.drm-trigger+xml
 application/vnd.oma.bcast.imd+xml
@@ -828,7 +874,7 @@ application/vnd.oma.cab-subs-invite+xml
 application/vnd.oma.cab-user-prefs+xml
 application/vnd.oma.dcd
 application/vnd.oma.dcdc
-application/vnd.oma.dd2+xml     dd2
+application/vnd.oma.dd2+xml			dd2
 application/vnd.oma.drm.risd+xml
 application/vnd.oma.group-usage-list+xml
 application/vnd.oma.pal+xml
@@ -847,8 +893,11 @@ application/vnd.omads-email+xml
 application/vnd.omads-file+xml
 application/vnd.omads-folder+xml
 application/vnd.omaloc-supl-init
-application/vnd.openeye.oeb     oeb
-application/vnd.openofficeorg.extension   oxt
+application/vnd.onepager			tam
+application/vnd.openblox.game+xml		obgx
+application/vnd.openblox.game-binary		obg
+application/vnd.openeye.oeb			oeb
+application/vnd.openofficeorg.extension		oxt
 application/vnd.openxmlformats-officedocument.custom-properties+xml
 application/vnd.openxmlformats-officedocument.customXmlProperties+xml
 application/vnd.openxmlformats-officedocument.drawing+xml
@@ -867,16 +916,16 @@ application/vnd.openxmlformats-officedocument.presentationml.notesSlide+xml
 application/vnd.openxmlformats-officedocument.presentationml.presProps+xml
 application/vnd.openxmlformats-officedocument.presentationml.presentation pptx
 application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml
-application/vnd.openxmlformats-officedocument.presentationml.slide  sldx
+application/vnd.openxmlformats-officedocument.presentationml.slide	sldx
 application/vnd.openxmlformats-officedocument.presentationml.slide+xml
 application/vnd.openxmlformats-officedocument.presentationml.slideLayout+xml
 application/vnd.openxmlformats-officedocument.presentationml.slideMaster+xml
 application/vnd.openxmlformats-officedocument.presentationml.slideUpdateInfo+xml
-application/vnd.openxmlformats-officedocument.presentationml.slideshow  ppsx
+application/vnd.openxmlformats-officedocument.presentationml.slideshow	ppsx
 application/vnd.openxmlformats-officedocument.presentationml.slideshow.main+xml
 application/vnd.openxmlformats-officedocument.presentationml.tableStyles+xml
 application/vnd.openxmlformats-officedocument.presentationml.tags+xml
-application/vnd.openxmlformats-officedocument.presentationml.template potx
+application/vnd.openxmlformats-officedocument.presentationml.template	potx
 application/vnd.openxmlformats-officedocument.presentationml.template.main+xml
 application/vnd.openxmlformats-officedocument.presentationml.viewProps+xml
 application/vnd.openxmlformats-officedocument.spreadsheetml.calcChain+xml
@@ -892,13 +941,13 @@ application/vnd.openxmlformats-officedocument.spreadsheetml.queryTable+xml
 application/vnd.openxmlformats-officedocument.spreadsheetml.revisionHeaders+xml
 application/vnd.openxmlformats-officedocument.spreadsheetml.revisionLog+xml
 application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml
-application/vnd.openxmlformats-officedocument.spreadsheetml.sheet xlsx
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet	xlsx
 application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml
 application/vnd.openxmlformats-officedocument.spreadsheetml.sheetMetadata+xml
 application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml
 application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml
 application/vnd.openxmlformats-officedocument.spreadsheetml.tableSingleCells+xml
-application/vnd.openxmlformats-officedocument.spreadsheetml.template  xltx
+application/vnd.openxmlformats-officedocument.spreadsheetml.template	xltx
 application/vnd.openxmlformats-officedocument.spreadsheetml.template.main+xml
 application/vnd.openxmlformats-officedocument.spreadsheetml.userNames+xml
 application/vnd.openxmlformats-officedocument.spreadsheetml.volatileDependencies+xml
@@ -907,7 +956,7 @@ application/vnd.openxmlformats-officedocument.theme+xml
 application/vnd.openxmlformats-officedocument.themeOverride+xml
 application/vnd.openxmlformats-officedocument.vmlDrawing
 application/vnd.openxmlformats-officedocument.wordprocessingml.comments+xml
-application/vnd.openxmlformats-officedocument.wordprocessingml.document docx
+application/vnd.openxmlformats-officedocument.wordprocessingml.document	docx
 application/vnd.openxmlformats-officedocument.wordprocessingml.document.glossary+xml
 application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml
 application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml
@@ -917,7 +966,7 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml
 application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml
 application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml
 application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml
-application/vnd.openxmlformats-officedocument.wordprocessingml.template dotx
+application/vnd.openxmlformats-officedocument.wordprocessingml.template	dotx
 application/vnd.openxmlformats-officedocument.wordprocessingml.template.main+xml
 application/vnd.openxmlformats-officedocument.wordprocessingml.webSettings+xml
 application/vnd.openxmlformats-package.core-properties+xml
@@ -925,42 +974,44 @@ application/vnd.openxmlformats-package.digital-signature-xmlsignature+xml
 application/vnd.openxmlformats-package.relationships+xml
 application/vnd.oracle.resource+json
 application/vnd.orange.indata
-application/vnd.osa.netdeploy     ndc
-application/vnd.osgeo.mapguide.package    mgp
+application/vnd.osa.netdeploy			ndc
+application/vnd.osgeo.mapguide.package		mgp
 # jar: application/x-java-archive
 application/vnd.osgi.bundle
-application/vnd.osgi.dp       dp
-application/vnd.osgi.subsystem      esa
+application/vnd.osgi.dp				dp
+application/vnd.osgi.subsystem			esa
 application/vnd.otps.ct-kip+xml
-application/vnd.palm        prc pdb pqa oprc
-application/vnd.panoply       plp
+application/vnd.oxli.countgraph			oxlicg
+application/vnd.pagerduty+json
+application/vnd.palm				prc pdb pqa oprc
+application/vnd.panoply				plp
 application/vnd.paos+xml
-application/vnd.pawaafile     paw
+application/vnd.pawaafile			paw
 application/vnd.pcos
-application/vnd.pg.format         str
-application/vnd.pg.osasli     ei6
-application/vnd.piaccess.application-license  pil
-application/vnd.picsel        efif
-application/vnd.pmi.widget      wg
+application/vnd.pg.format		    	str
+application/vnd.pg.osasli			ei6
+application/vnd.piaccess.application-license	pil
+application/vnd.picsel				efif
+application/vnd.pmi.widget			wg
 application/vnd.poc.group-advertisement+xml
-application/vnd.pocketlearn     plf
-application/vnd.powerbuilder6     pbd
+application/vnd.pocketlearn			plf
+application/vnd.powerbuilder6			pbd
 application/vnd.powerbuilder6-s
 application/vnd.powerbuilder7
 application/vnd.powerbuilder7-s
 application/vnd.powerbuilder75
 application/vnd.powerbuilder75-s
-application/vnd.preminet      preminet
-application/vnd.previewsystems.box    box vbox
-application/vnd.proteus.magazine    mgz
-application/vnd.publishare-delta-tree   qps
+application/vnd.preminet			preminet
+application/vnd.previewsystems.box		box vbox
+application/vnd.proteus.magazine		mgz
+application/vnd.publishare-delta-tree		qps
 # pti: image/prs.pti
-application/vnd.pvi.ptid1     ptid
+application/vnd.pvi.ptid1			ptid
 application/vnd.pwg-multiplexed
 application/vnd.pwg-xhtml-print+xml
-application/vnd.qualcomm.brew-app-res   bar
-application/vnd.Quark.QuarkXPress   qxd qxt qwd qwt qxl qxb
-application/vnd.quobject-quoxdocument   quox quiz
+application/vnd.qualcomm.brew-app-res		bar
+application/vnd.Quark.QuarkXPress		qxd qxt qwd qwt qxl qxb
+application/vnd.quobject-quoxdocument		quox quiz
 application/vnd.radisys.moml+xml
 application/vnd.radisys.msml-audit-conf+xml
 application/vnd.radisys.msml-audit-conn+xml
@@ -976,88 +1027,89 @@ application/vnd.radisys.msml-dialog-speech+xml
 application/vnd.radisys.msml-dialog-transform+xml
 application/vnd.radisys.msml-dialog+xml
 application/vnd.radisys.msml+xml
-application/vnd.rainstor.data     tree
+application/vnd.rainstor.data			tree
 application/vnd.rapid
-application/vnd.realvnc.bed     bed
-application/vnd.recordare.musicxml    mxl
+application/vnd.realvnc.bed			bed
+application/vnd.recordare.musicxml		mxl
 application/vnd.recordare.musicxml+xml
 application/vnd.RenLearn.rlprint
-application/vnd.rig.cryptonote      cryptonote
-application/vnd.route66.link66+xml    link66
+application/vnd.rig.cryptonote			cryptonote
+application/vnd.route66.link66+xml		link66
 # gbr: application/rpki-ghostbusters
 application/vnd.rs-274x
 application/vnd.ruckus.download
 application/vnd.s3sms
-application/vnd.sailingtracker.track    st
+application/vnd.sailingtracker.track		st
 application/vnd.sbm.cid
 application/vnd.sbm.mid2
-application/vnd.scribus       scd sla slaz
-application/vnd.sealed.3df      s3df
-application/vnd.sealed.csf      scsf
-application/vnd.sealed.doc      sdoc sdo s1w
-application/vnd.sealed.eml      seml sem
-application/vnd.sealed.mht      smht smh
+application/vnd.scribus				scd sla slaz
+application/vnd.sealed.3df			s3df
+application/vnd.sealed.csf			scsf
+application/vnd.sealed.doc			sdoc sdo s1w
+application/vnd.sealed.eml			seml sem
+application/vnd.sealed.mht			smht smh
 application/vnd.sealed.net
 # spp: application/scvp-vp-response
-application/vnd.sealed.ppt      sppt s1p
-application/vnd.sealed.tiff     stif
-application/vnd.sealed.xls      sxls sxl s1e
+application/vnd.sealed.ppt			sppt s1p
+application/vnd.sealed.tiff			stif
+application/vnd.sealed.xls			sxls sxl s1e
 # stm: audio/x-stm
-application/vnd.sealedmedia.softseal.html stml s1h
-application/vnd.sealedmedia.softseal.pdf  spdf spd s1a
-application/vnd.seemail       see
-application/vnd.sema        sema
-application/vnd.semd        semd
-application/vnd.semf        semf
-application/vnd.shana.informed.formdata   ifm
-application/vnd.shana.informed.formtemplate itp
-application/vnd.shana.informed.interchange  iif
-application/vnd.shana.informed.package    ipk
-application/vnd.SimTech-MindMapper    twd twds
+application/vnd.sealedmedia.softseal.html	stml s1h
+application/vnd.sealedmedia.softseal.pdf	spdf spd s1a
+application/vnd.seemail				see
+application/vnd.sema				sema
+application/vnd.semd				semd
+application/vnd.semf				semf
+application/vnd.shana.informed.formdata		ifm
+application/vnd.shana.informed.formtemplate	itp
+application/vnd.shana.informed.interchange	iif
+application/vnd.shana.informed.package		ipk
+application/vnd.SimTech-MindMapper		twd twds
 application/vnd.siren+json
-application/vnd.smaf        mmf
-application/vnd.smart.notebook      notebook
-application/vnd.smart.teacher     teacher
-application/vnd.software602.filler.form+xml fo
-application/vnd.software602.filler.form-xml-zip zfo
-application/vnd.solent.sdkm+xml     sdkm sdkd
-application/vnd.spotfire.dxp      dxp
-application/vnd.spotfire.sfs      sfs
+application/vnd.smaf				mmf
+application/vnd.smart.notebook			notebook
+application/vnd.smart.teacher			teacher
+application/vnd.software602.filler.form+xml	fo
+application/vnd.software602.filler.form-xml-zip	zfo
+application/vnd.solent.sdkm+xml			sdkm sdkd
+application/vnd.spotfire.dxp			dxp
+application/vnd.spotfire.sfs			sfs
 application/vnd.sss-cod
 application/vnd.sss-dtf
 application/vnd.sss-ntf
-application/vnd.stepmania.package   smzip
-application/vnd.stepmania.stepchart   sm
+application/vnd.stepmania.package		smzip
+application/vnd.stepmania.stepchart		sm
 application/vnd.street-stream
-application/vnd.sun.wadl+xml      wadl
-application/vnd.sus-calendar      sus susp
+application/vnd.sun.wadl+xml			wadl
+application/vnd.sus-calendar			sus susp
 application/vnd.svd
 application/vnd.swiftview-ics
-application/vnd.syncml+xml      xsm
-application/vnd.syncml.dm+wbxml     bdm
-application/vnd.syncml.dm+xml     xdm
+application/vnd.syncml+xml			xsm
+application/vnd.syncml.dm+wbxml			bdm
+application/vnd.syncml.dm+xml			xdm
 application/vnd.syncml.dm.notification
 application/vnd.syncml.dmddf+wbxml
-application/vnd.syncml.dmddf+xml    ddf
+application/vnd.syncml.dmddf+xml		ddf
 application/vnd.syncml.dmtnds+wbxml
 application/vnd.syncml.dmtnds+xml
 application/vnd.syncml.ds.notification
-application/vnd.tao.intent-module-archive tao
-application/vnd.tcpdump.pcap      pcap cap dmp
-application/vnd.theqvd        qvd
+application/vnd.tao.intent-module-archive	tao
+application/vnd.tcpdump.pcap			pcap cap dmp
+application/vnd.theqvd				qvd
 application/vnd.tmd.mediaflex.api+xml
-application/vnd.tmobile-livetv      tmo
-application/vnd.trid.tpt      tpt
-application/vnd.triscape.mxs      mxs
-application/vnd.trueapp       tra
+application/vnd.tml				vfr viaframe
+application/vnd.tmobile-livetv			tmo
+application/vnd.trid.tpt			tpt
+application/vnd.triscape.mxs			mxs
+application/vnd.trueapp				tra
 application/vnd.truedoc
 # cab: application/vnd.ms-cab-compressed
 application/vnd.ubisoft.webplayer
-application/vnd.ufdl        ufdl ufd frm
-application/vnd.uiq.theme     utz
-application/vnd.umajin        umj
-application/vnd.unity       unityweb
-application/vnd.uoml+xml      uoml uo
+application/vnd.ufdl				ufdl ufd frm
+application/vnd.uiq.theme			utz
+application/vnd.umajin				umj
+application/vnd.unity				unityweb
+application/vnd.uoml+xml			uoml uo
 application/vnd.uplanet.alert
 application/vnd.uplanet.alert-wbxml
 application/vnd.uplanet.bearer-choice
@@ -1071,130 +1123,131 @@ application/vnd.uplanet.list-wbxml
 application/vnd.uplanet.listcmd
 application/vnd.uplanet.listcmd-wbxml
 application/vnd.uplanet.signal
-application/vnd.valve.source.material   vmt
-application/vnd.vcx       vcx
+application/vnd.uri-map				urim urimap
+application/vnd.valve.source.material		vmt
+application/vnd.vcx				vcx
 # sxi: application/vnd.sun.xml.impress
-application/vnd.vd-study      mxi study-inter model-inter
+application/vnd.vd-study			mxi study-inter model-inter
 # mcd: application/vnd.mcd
-application/vnd.vectorworks     vwx
+application/vnd.vectorworks			vwx
+application/vnd.vel+json
 application/vnd.verimatrix.vcas
-application/vnd.vidsoft.vidconference   vsc
-application/vnd.visio       vsd vst vsw vss
-application/vnd.visionary     vis
+application/vnd.vidsoft.vidconference		vsc
+application/vnd.visio				vsd vst vsw vss
+application/vnd.visionary			vis
 # vsc: application/vnd.vidsoft.vidconference
 application/vnd.vividence.scriptfile
-application/vnd.vsf       vsf
-application/vnd.wap.sic       sic
-application/vnd.wap.slc       slc
-application/vnd.wap.wbxml     wbxml
-application/vnd.wap.wmlc      wmlc
-application/vnd.wap.wmlscriptc      wmlsc
-application/vnd.webturbo      wtb
-application/vnd.wfa.p2p       p2p
-application/vnd.wfa.wsc       wsc
+application/vnd.vsf				vsf
+application/vnd.wap.sic				sic
+application/vnd.wap.slc				slc
+application/vnd.wap.wbxml			wbxml
+application/vnd.wap.wmlc			wmlc
+application/vnd.wap.wmlscriptc			wmlsc
+application/vnd.webturbo			wtb
+application/vnd.wfa.p2p				p2p
+application/vnd.wfa.wsc				wsc
 application/vnd.windows.devicepairing
-application/vnd.wmc       wmc
+application/vnd.wmc				wmc
 application/vnd.wmf.bootstrap
 # nb: application/mathematica for now
 application/vnd.wolfram.mathematica
-application/vnd.wolfram.mathematica.package m
-application/vnd.wolfram.player      nbp
-application/vnd.wordperfect     wpd
-application/vnd.wqd       wqd
+application/vnd.wolfram.mathematica.package	m
+application/vnd.wolfram.player			nbp
+application/vnd.wordperfect			wpd
+application/vnd.wqd				wqd
 application/vnd.wrq-hp3000-labelled
-application/vnd.wt.stf        stf
+application/vnd.wt.stf				stf
 application/vnd.wv.csp+xml
-application/vnd.wv.csp+wbxml      wv
+application/vnd.wv.csp+wbxml			wv
 application/vnd.wv.ssp+xml
 application/vnd.xacml+json
-application/vnd.xara        xar
-application/vnd.xfdl        xfdl xfd
+application/vnd.xara				xar
+application/vnd.xfdl				xfdl xfd
 application/vnd.xfdl.webform
 application/vnd.xmi+xml
-application/vnd.xmpie.cpkg      cpkg
-application/vnd.xmpie.dpkg      dpkg
+application/vnd.xmpie.cpkg			cpkg
+application/vnd.xmpie.dpkg			dpkg
 # dpkg: application/vnd.xmpie.dpkg
 application/vnd.xmpie.plan
-application/vnd.xmpie.ppkg      ppkg
-application/vnd.xmpie.xlim      xlim
-application/vnd.yamaha.hv-dic     hvd
-application/vnd.yamaha.hv-script    hvs
-application/vnd.yamaha.hv-voice     hvp
-application/vnd.yamaha.openscoreformat    osf
+application/vnd.xmpie.ppkg			ppkg
+application/vnd.xmpie.xlim			xlim
+application/vnd.yamaha.hv-dic			hvd
+application/vnd.yamaha.hv-script		hvs
+application/vnd.yamaha.hv-voice			hvp
+application/vnd.yamaha.openscoreformat		osf
 application/vnd.yamaha.openscoreformat.osfpvg+xml
 application/vnd.yamaha.remote-setup
-application/vnd.yamaha.smaf-audio   saf
-application/vnd.yamaha.smaf-phrase    spf
+application/vnd.yamaha.smaf-audio		saf
+application/vnd.yamaha.smaf-phrase		spf
 application/vnd.yamaha.through-ngn
 application/vnd.yamaha.tunnel-udpencap
-application/vnd.yaoweme       yme
-application/vnd.yellowriver-custom-menu   cmp
-application/vnd.zul       zir zirz
-application/vnd.zzazz.deck+xml      zaz
-application/voicexml+xml      vxml
+application/vnd.yaoweme				yme
+application/vnd.yellowriver-custom-menu		cmp
+application/vnd.zul				zir zirz
+application/vnd.zzazz.deck+xml			zaz
+application/voicexml+xml			vxml
 application/vq-rtcp-xr
-application/watcherinfo+xml     wif
+application/watcherinfo+xml			wif
 application/whoispp-query
 application/whoispp-response
-application/widget        wgt
+application/widget				wgt
 application/wita
 application/wordperfect5.1
-application/wsdl+xml        wsdl
-application/wspolicy+xml      wspolicy
+application/wsdl+xml				wsdl
+application/wspolicy+xml			wspolicy
 # yes, this *is* IANA registered despite of x-
 application/x-www-form-urlencoded
 application/x400-bp
 application/xacml+xml
-application/xcap-att+xml      xav
-application/xcap-caps+xml     xca
-application/xcap-diff+xml     xdf
-application/xcap-el+xml       xel
-application/xcap-error+xml      xer
-application/xcap-ns+xml       xns
+application/xcap-att+xml			xav
+application/xcap-caps+xml			xca
+application/xcap-diff+xml			xdf
+application/xcap-el+xml				xel
+application/xcap-error+xml			xer
+application/xcap-ns+xml				xns
 application/xcon-conference-info-diff+xml
 application/xcon-conference-info+xml
 application/xenc+xml
-application/xhtml+xml       xhtml xhtm xht
-# application/xhtml-voice+xml obsoleted by application/xv+xml
+application/xhtml+xml				xhtml xhtm xht
 # xml, xsd, rng: text/xml
 application/xml
 # mod: audio/x-mod
-application/xml-dtd       dtd
+application/xml-dtd				dtd
 # ent: text/xml-external-parsed-entity
 application/xml-external-parsed-entity
 application/xml-patch+xml
 application/xmpp+xml
-application/xop+xml       xop
-application/xslt+xml        xsl xslt
-application/xv+xml        mxml xhvml xvml xvm
-application/yang        yang
-application/yin+xml       yin
-application/zip         zip
+application/xop+xml				xop
+application/xslt+xml				xsl xslt
+application/xv+xml				mxml xhvml xvml xvm
+application/yang				yang
+application/yin+xml				yin
+application/zip					zip
 application/zlib
 audio/1d-interleaved-parityfec
-audio/32kadpcm          726
+audio/32kadpcm					726
 # 3gp, 3gpp: video/3gpp
 audio/3gpp
 # 3g2, 3gpp2: video/3gpp2
 audio/3gpp2
-audio/ac3         ac3
-audio/AMR         amr
-audio/AMR-WB          awb
+audio/ac3					ac3
+audio/AMR					amr
+audio/AMR-WB					awb
 audio/amr-wb+
 audio/aptx
-audio/asc         acn
+audio/asc					acn
 # aa3, omg: audio/ATRAC3
-audio/ATRAC-ADVANCED-LOSSLESS     aal
+audio/ATRAC-ADVANCED-LOSSLESS			aal
 # aa3, omg: audio/ATRAC3
-audio/ATRAC-X         atx
-audio/ATRAC3          at3 aa3 omg
-audio/basic         au snd
+audio/ATRAC-X					atx
+audio/ATRAC3					at3 aa3 omg
+audio/basic					au snd
 audio/BV16
 audio/BV32
 audio/clearmode
 audio/CN
 audio/DAT12
-audio/dls         dls
+audio/dls					dls
 audio/dsr-es201108
 audio/dsr-es202050
 audio/dsr-es202211
@@ -1203,22 +1256,24 @@ audio/DV
 audio/DVI4
 audio/eac3
 audio/encaprtp
-audio/EVRC          evc
+audio/EVRC					evc
 # qcp: audio/qcelp
 audio/EVRC-QCP
 audio/EVRC0
 audio/EVRC1
-audio/EVRCB         evb
+audio/EVRCB					evb
 audio/EVRCB0
 audio/EVRCB1
-audio/EVRCNW          enw
+audio/EVRCNW					enw
 audio/EVRCNW0
 audio/EVRCNW1
-audio/EVRCWB          evw
+audio/EVRCWB					evw
 audio/EVRCWB0
 audio/EVRCWB1
+audio/EVS
 audio/example
 audio/fwdred
+audio/G711-0
 audio/G719
 audio/G722
 audio/G7221
@@ -1235,37 +1290,38 @@ audio/G729E
 audio/GSM
 audio/GSM-EFR
 audio/GSM-HR-08
-audio/iLBC          lbc
+audio/iLBC					lbc
 audio/ip-mr_v2.5
 # wav: audio/x-wav
-audio/L16         l16
+audio/L16					l16
 audio/L20
 audio/L24
 audio/L8
 audio/LPC
-audio/mobile-xmf        mxmf
+audio/mobile-xmf				mxmf
 # mp4, mpg4: video/mp4, see RFC 4337
-audio/mp4         m4a
+audio/mp4					m4a
 audio/MP4A-LATM
 audio/MPA
 audio/mpa-robust
-audio/mpeg          mp3 mpga mp1 mp2
+audio/mpeg					mp3 mpga mp1 mp2
 audio/mpeg4-generic
-audio/ogg         oga ogg opus spx
+audio/ogg					oga ogg opus spx
+audio/opus
 audio/parityfec
 audio/PCMA
 audio/PCMA-WB
 audio/PCMU
 audio/PCMU-WB
-audio/prs.sid         sid psid
-audio/qcelp         qcp
+audio/prs.sid					sid psid
+audio/qcelp					qcp
 audio/raptorfec
 audio/RED
 audio/rtp-enc-aescm128
 audio/rtp-midi
 audio/rtploopback
 audio/rtx
-audio/SMV         smv
+audio/SMV					smv
 # qcp: audio/qcelp, see RFC 3625
 audio/SMV-QCP
 audio/SMV0
@@ -1282,18 +1338,18 @@ audio/VDVI
 audio/VMR-WB
 audio/vnd.3gpp.iufp
 audio/vnd.4SB
-audio/vnd.audikoz       koz
+audio/vnd.audikoz				koz
 audio/vnd.CELP
 audio/vnd.cisco.nse
 audio/vnd.cmles.radio-events
 audio/vnd.cns.anp1
 audio/vnd.cns.inf1
-audio/vnd.dece.audio        uva uvva
-audio/vnd.digital-winds       eol
+audio/vnd.dece.audio				uva uvva
+audio/vnd.digital-winds				eol
 audio/vnd.dlna.adts
 audio/vnd.dolby.heaac.1
 audio/vnd.dolby.heaac.2
-audio/vnd.dolby.mlp       mlp
+audio/vnd.dolby.mlp				mlp
 audio/vnd.dolby.mps
 audio/vnd.dolby.pl2
 audio/vnd.dolby.pl2x
@@ -1301,93 +1357,95 @@ audio/vnd.dolby.pl2z
 audio/vnd.dolby.pulse.1
 audio/vnd.dra
 # wav: audio/x-wav, cpt: application/mac-compactpro
-audio/vnd.dts         dts
-audio/vnd.dts.hd        dtshd
+audio/vnd.dts					dts
+audio/vnd.dts.hd				dtshd
 # dvb: video/vnd.dvb.file
 audio/vnd.dvb.file
-audio/vnd.everad.plj        plj
+audio/vnd.everad.plj				plj
 # rm: audio/x-pn-realaudio
 audio/vnd.hns.audio
-audio/vnd.lucent.voice        lvp
-audio/vnd.ms-playready.media.pya    pya
+audio/vnd.lucent.voice				lvp
+audio/vnd.ms-playready.media.pya		pya
 # mxmf: audio/mobile-xmf
 audio/vnd.nokia.mobile-xmf
-audio/vnd.nortel.vbk        vbk
-audio/vnd.nuera.ecelp4800     ecelp4800
-audio/vnd.nuera.ecelp7470     ecelp7470
-audio/vnd.nuera.ecelp9600     ecelp9600
+audio/vnd.nortel.vbk				vbk
+audio/vnd.nuera.ecelp4800			ecelp4800
+audio/vnd.nuera.ecelp7470			ecelp7470
+audio/vnd.nuera.ecelp9600			ecelp9600
 audio/vnd.octel.sbc
 # audio/vnd.qcelp deprecated in favour of audio/qcelp
 audio/vnd.rhetorex.32kadpcm
-audio/vnd.rip         rip
-audio/vnd.sealedmedia.softseal.mpeg   smp3 smp s1m
+audio/vnd.rip					rip
+audio/vnd.sealedmedia.softseal.mpeg		smp3 smp s1m
 audio/vnd.vmx.cvsd
 audio/vorbis
 audio/vorbis-config
-image/cgm         cgm
+image/cgm					cgm
 image/example
-image/fits          fits fit fts
+image/fits					fits fit fts
 image/g3fax
-image/gif         gif
-image/ief         ief
-image/jp2         jp2 jpg2
-image/jpeg          jpg jpeg jpe jfif
-image/jpm         jpm jpgm
-image/jpx         jpx jpf
-image/ktx         ktx
+image/gif					gif
+image/ief					ief
+image/jp2					jp2 jpg2
+image/jpeg					jpg jpeg jpe jfif
+image/jpm					jpm jpgm
+image/jpx					jpx jpf
+image/ktx					ktx
 image/naplps
-image/png         png
-image/prs.btif          btif btf
-image/prs.pti         pti
+image/png					png
+image/prs.btif					btif btf
+image/prs.pti					pti
 image/pwg-raster
-image/svg+xml         svg svgz
-image/t38         t38
-image/tiff          tiff tif
-image/tiff-fx         tfx
-image/vnd.adobe.photoshop     psd
-image/vnd.airzip.accelerator.azv    azv
+image/svg+xml					svg svgz
+image/t38					t38
+image/tiff					tiff tif
+image/tiff-fx					tfx
+image/vnd.adobe.photoshop			psd
+image/vnd.airzip.accelerator.azv		azv
 image/vnd.cns.inf2
-image/vnd.dece.graphic        uvi uvvi uvg uvvg
-image/vnd.djvu          djvu djv
+image/vnd.dece.graphic				uvi uvvi uvg uvvg
+image/vnd.djvu					djvu djv
 # sub: text/vnd.dvb.subtitle
 image/vnd.dvb.subtitle
-image/vnd.dwg         dwg
-image/vnd.dxf         dxf
-image/vnd.fastbidsheet        fbs
-image/vnd.fpx         fpx
-image/vnd.fst         fst
-image/vnd.fujixerox.edmics-mmr      mmr
-image/vnd.fujixerox.edmics-rlc      rlc
-image/vnd.globalgraphics.pgb      pgb
-image/vnd.microsoft.icon      ico
+image/vnd.dwg					dwg
+image/vnd.dxf					dxf
+image/vnd.fastbidsheet				fbs
+image/vnd.fpx					fpx
+image/vnd.fst					fst
+image/vnd.fujixerox.edmics-mmr			mmr
+image/vnd.fujixerox.edmics-rlc			rlc
+image/vnd.globalgraphics.pgb			pgb
+image/vnd.microsoft.icon			ico
 image/vnd.mix
-image/vnd.ms-modi       mdi
+image/vnd.mozilla.apng				apng
+image/vnd.ms-modi				mdi
 image/vnd.net-fpx
-image/vnd.radiance        hdr rgbe xyze
-image/vnd.sealed.png        spng spn s1n
-image/vnd.sealedmedia.softseal.gif    sgif sgi s1g
-image/vnd.sealedmedia.softseal.jpg    sjpg sjp s1j
+image/vnd.radiance				hdr rgbe xyze
+image/vnd.sealed.png				spng spn s1n
+image/vnd.sealedmedia.softseal.gif		sgif sgi s1g
+image/vnd.sealedmedia.softseal.jpg		sjpg sjp s1j
 image/vnd.svf
-image/vnd.tencent.tap       tap
-image/vnd.valve.source.texture      vtf
-image/vnd.wap.wbmp        wbmp
-image/vnd.xiff          xif
+image/vnd.tencent.tap				tap
+image/vnd.valve.source.texture			vtf
+image/vnd.wap.wbmp				wbmp
+image/vnd.xiff					xif
+image/vnd.zbrush.pcx				pcx
 message/CPIM
 message/delivery-status
 message/disposition-notification
 message/example
 message/external-body
 message/feedback-report
-message/global          u8msg
-message/global-delivery-status      u8dsn
-message/global-disposition-notification   u8mdn
-message/global-headers        u8hdr
+message/global					u8msg
+message/global-delivery-status			u8dsn
+message/global-disposition-notification		u8mdn
+message/global-headers				u8hdr
 message/http
 # cl: application/simple-filter+xml
 message/imdn+xml
 # message/news obsoleted by message/rfc822
 message/partial
-message/rfc822          eml mail art
+message/rfc822					eml mail art
 message/s-http
 message/sip
 message/sipfrag
@@ -1396,28 +1454,29 @@ message/vnd.si.simp
 # wsc: application/vnd.wfa.wsc
 message/vnd.wfa.wsc
 model/example
-model/iges          igs iges
-model/mesh          msh mesh silo
-model/vnd.collada+xml       dae
-model/vnd.dwf         dwf
+model/iges					igs iges
+model/mesh					msh mesh silo
+model/vnd.collada+xml				dae
+model/vnd.dwf					dwf
 # 3dml, 3dm: text/vnd.in3d.3dml
 model/vnd.flatland.3dml
-model/vnd.gdl         gdl gsm win dor lmp rsm msm ism
+model/vnd.gdl					gdl gsm win dor lmp rsm msm ism
 model/vnd.gs-gdl
-model/vnd.gtw         gtw
-model/vnd.moml+xml        moml
-model/vnd.mts         mts
-model/vnd.opengex       ogex
-model/vnd.parasolid.transmit.binary   x_b xmt_bin
-model/vnd.parasolid.transmit.text   x_t xmt_txt
-model/vnd.valve.source.compiled-map   bsp
-model/vnd.vtu         vtu
-model/vrml          wrl vrml
+model/vnd.gtw					gtw
+model/vnd.moml+xml				moml
+model/vnd.mts					mts
+model/vnd.opengex				ogex
+model/vnd.parasolid.transmit.binary		x_b xmt_bin
+model/vnd.parasolid.transmit.text		x_t xmt_txt
+model/vnd.rosette.annotated-data-model
+model/vnd.valve.source.compiled-map		bsp
+model/vnd.vtu					vtu
+model/vrml					wrl vrml
 # x3db: model/x3d+xml
 model/x3d+fastinfoset
 # x3d: application/vnd.hzn-3d-crossword
-model/x3d+xml         x3db
-model/x3d-vrml          x3dv x3dvz
+model/x3d+xml					x3db
+model/x3d-vrml					x3dv x3dvz
 multipart/alternative
 multipart/appledouble
 multipart/byteranges
@@ -1430,83 +1489,84 @@ multipart/parallel
 multipart/related
 multipart/report
 multipart/signed
-multipart/voice-message       vpm
+multipart/voice-message				vpm
 multipart/x-mixed-replace
 text/1d-interleaved-parityfec
-text/cache-manifest       appcache manifest
-text/calendar         ics ifb
-text/css          css
-text/csv          csv
-text/csv-schema         csvs
+text/cache-manifest				appcache manifest
+text/calendar					ics ifb
+text/css					css
+text/csv					csv
+text/csv-schema					csvs
 text/directory
-text/dns          soa zone
+text/dns					soa zone
 text/encaprtp
 # text/ecmascript obsoleted by application/ecmascript
 text/enriched
 text/example
 text/fwdred
 text/grammar-ref-list
-text/html         html htm
+text/html					html htm
 # text/javascript obsoleted by application/javascript
-text/jcr-cnd          cnd
-text/markdown         markdown md
-text/mizar          miz
-text/n3           n3
+text/jcr-cnd					cnd
+text/markdown					markdown md
+text/mizar					miz
+text/n3						n3
 text/parameters
 text/parityfec
-text/plain    txt asc text pm el c h cc hh cxx hxx f90 conf log
-text/provenance-notation      provn
-text/prs.fallenstein.rst      rst
-text/prs.lines.tag        tag dsc
+text/plain		txt asc text pm el c h cc hh cxx hxx f90 conf log
+text/provenance-notation			provn
+text/prs.fallenstein.rst			rst
+text/prs.lines.tag				tag dsc
+text/prs.prop.logic
 text/raptorfec
 text/RED
 text/rfc822-headers
-text/richtext         rtx
+text/richtext					rtx
 # rtf: application/rtf
 text/rtf
 text/rtp-enc-aescm128
 text/rtploopback
 text/rtx
-text/sgml         sgml sgm
+text/sgml					sgml sgm
 text/t140
-text/tab-separated-values     tsv
-text/troff          t tr roff
-text/turtle         ttl
+text/tab-separated-values			tsv
+text/troff					t tr roff
+text/turtle					ttl
 text/ulpfec
-text/uri-list         uris uri
-text/vcard          vcf vcard
-text/vnd.a          a
-text/vnd.abc          abc
+text/uri-list					uris uri
+text/vcard					vcf vcard
+text/vnd.a					a
+text/vnd.abc					abc
 # curl: application/vnd.curl
 text/vnd.curl
-text/vnd.debian.copyright     copyright
-text/vnd.DMClientScript       dms
-text/vnd.dvb.subtitle       sub
-text/vnd.esmertec.theme-descriptor    jtd
-text/vnd.fly          fly
-text/vnd.fmi.flexstor       flx
-text/vnd.graphviz       gv dot
-text/vnd.in3d.3dml        3dml 3dm
-text/vnd.in3d.spot        spot spo
+text/vnd.debian.copyright			copyright
+text/vnd.DMClientScript				dms
+text/vnd.dvb.subtitle				sub
+text/vnd.esmertec.theme-descriptor		jtd
+text/vnd.fly					fly
+text/vnd.fmi.flexstor				flx
+text/vnd.graphviz				gv dot
+text/vnd.in3d.3dml				3dml 3dm
+text/vnd.in3d.spot				spot spo
 text/vnd.IPTC.NewsML
 text/vnd.IPTC.NITF
 text/vnd.latex-z
 text/vnd.motorola.reflex
-text/vnd.ms-mediapackage      mpf
-text/vnd.net2phone.commcenter.command   ccc
+text/vnd.ms-mediapackage			mpf
+text/vnd.net2phone.commcenter.command		ccc
 text/vnd.radisys.msml-basic-layout
-text/vnd.si.uricatalogue      uric
-text/vnd.sun.j2me.app-descriptor    jad
-text/vnd.trolltech.linguist     ts
-text/vnd.wap.si         si
-text/vnd.wap.sl         sl
-text/vnd.wap.wml        wml
-text/vnd.wap.wmlscript        wmls
-text/xml          xml xsd rng
-text/xml-external-parsed-entity     ent
+text/vnd.si.uricatalogue			uric
+text/vnd.sun.j2me.app-descriptor		jad
+text/vnd.trolltech.linguist			ts
+text/vnd.wap.si					si
+text/vnd.wap.sl					sl
+text/vnd.wap.wml				wml
+text/vnd.wap.wmlscript				wmls
+text/xml					xml xsd rng
+text/xml-external-parsed-entity			ent
 video/1d-interleaved-parityfec
-video/3gpp          3gp 3gpp
-video/3gpp2         3g2 3gpp2
+video/3gpp					3gp 3gpp
+video/3gpp2					3g2 3gpp2
 video/3gpp-tt
 video/BMPEG
 video/BT656
@@ -1521,23 +1581,24 @@ video/H263-2000
 video/H264
 video/H264-RCDO
 video/H264-SVC
-video/iso.segment       m4s
+video/H265
+video/iso.segment				m4s
 video/JPEG
 video/jpeg2000
-video/mj2         mj2 mjp2
+video/mj2					mj2 mjp2
 video/MP1S
 video/MP2P
 video/MP2T
-video/mp4         mp4 mpg4 m4v
+video/mp4					mp4 mpg4 m4v
 video/MP4V-ES
-video/mpeg          mpeg mpg mpe m1v m2v
+video/mpeg					mpeg mpg mpe m1v m2v
 video/mpeg4-generic
 video/MPV
 video/nv
-video/ogg         ogv
+video/ogg					ogv
 video/parityfec
 video/pointer
-video/quicktime         mov qt
+video/quicktime					mov qt
 video/raptorfec
 video/raw
 video/rtp-enc-aescm128
@@ -1547,17 +1608,17 @@ video/SMPTE292M
 video/ulpfec
 video/vc1
 video/vnd.CCTV
-video/vnd.dece.hd       uvh uvvh
-video/vnd.dece.mobile       uvm uvvm
-video/vnd.dece.mp4        uvu uvvu
-video/vnd.dece.pd       uvp uvvp
-video/vnd.dece.sd       uvs uvvs
-video/vnd.dece.video        uvv uvvv
+video/vnd.dece.hd				uvh uvvh
+video/vnd.dece.mobile				uvm uvvm
+video/vnd.dece.mp4				uvu uvvu
+video/vnd.dece.pd				uvp uvvp
+video/vnd.dece.sd				uvs uvvs
+video/vnd.dece.video				uvv uvvv
 video/vnd.directv.mpeg
 video/vnd.directv.mpeg-tts
 video/vnd.dlna.mpeg-tts
-video/vnd.dvb.file        dvb
-video/vnd.fvt         fvt
+video/vnd.dvb.file				dvb
+video/vnd.fvt					fvt
 # rm: audio/x-pn-realaudio
 video/vnd.hns.video
 video/vnd.iptvforum.1dparityfec-1010
@@ -1568,131 +1629,132 @@ video/vnd.iptvforum.ttsavc
 video/vnd.iptvforum.ttsmpeg2
 video/vnd.motorola.video
 video/vnd.motorola.videop
-video/vnd.mpegurl       mxu m4u
-video/vnd.ms-playready.media.pyv    pyv
-video/vnd.nokia.interleaved-multimedia    nim
+video/vnd.mpegurl				mxu m4u
+video/vnd.ms-playready.media.pyv		pyv
+video/vnd.nokia.interleaved-multimedia		nim
 video/vnd.nokia.videovoip
 # mp4: video/mp4
 video/vnd.objectvideo
-video/vnd.radgamettools.bink      bik bk2
-video/vnd.radgamettools.smacker     smk
-video/vnd.sealed.mpeg1        smpg s11
+video/vnd.radgamettools.bink			bik bk2
+video/vnd.radgamettools.smacker			smk
+video/vnd.sealed.mpeg1				smpg s11
 # smpg: video/vnd.sealed.mpeg1
-video/vnd.sealed.mpeg4        s14
-video/vnd.sealed.swf        sswf ssw
-video/vnd.sealedmedia.softseal.mov    smov smo s1q
+video/vnd.sealed.mpeg4				s14
+video/vnd.sealed.swf				sswf ssw
+video/vnd.sealedmedia.softseal.mov		smov smo s1q
 # uvu, uvvu: video/vnd.dece.mp4
 video/vnd.uvvu.mp4
-video/vnd.vivo          viv
+video/vnd.vivo					viv
+video/VP8
 
 # Non-IANA types
 
-application/mac-compactpro      cpt
-application/metalink+xml      metalink
-application/owl+xml       owx
-application/rss+xml       rss
-application/vnd.android.package-archive   apk
-application/vnd.oma.dd+xml      dd
-application/vnd.oma.drm.content     dcf
+application/mac-compactpro			cpt
+application/metalink+xml			metalink
+application/owl+xml				owx
+application/rss+xml				rss
+application/vnd.android.package-archive		apk
+application/vnd.oma.dd+xml			dd
+application/vnd.oma.drm.content			dcf
 # odf: application/vnd.oasis.opendocument.formula
-application/vnd.oma.drm.dcf     o4a o4v
-application/vnd.oma.drm.message     dm
-application/vnd.oma.drm.rights+wbxml    drc
-application/vnd.oma.drm.rights+xml    dr
-application/vnd.sun.xml.calc      sxc
-application/vnd.sun.xml.calc.template   stc
-application/vnd.sun.xml.draw      sxd
-application/vnd.sun.xml.draw.template   std
-application/vnd.sun.xml.impress     sxi
-application/vnd.sun.xml.impress.template  sti
-application/vnd.sun.xml.math      sxm
-application/vnd.sun.xml.writer      sxw
-application/vnd.sun.xml.writer.global   sxg
-application/vnd.sun.xml.writer.template   stw
-application/vnd.symbian.install     sis
-application/vnd.wap.mms-message     mms
-application/x-annodex       anx
-application/x-bcpio       bcpio
-application/x-bittorrent      torrent
-application/x-bzip2       bz2
-application/x-cdlink        vcd
-application/x-chess-pgn       pgn
-application/x-chrome-extension      crx
-application/x-cpio        cpio
-application/x-csh       csh
-application/x-director        dcr dir dxr
-application/x-dvi       dvi
-application/x-futuresplash      spl
-application/x-gtar        gtar
-application/x-hdf       hdf
-application/x-java-archive      jar
-application/x-java-jnlp-file      jnlp
-application/x-java-pack200      pack
-application/x-killustrator      kil
-application/x-latex       latex
-application/x-netcdf        nc cdf
-application/x-perl        pl
-application/x-rpm       rpm
-application/x-sh        sh
-application/x-shar        shar
-application/x-shockwave-flash     swf
-application/x-stuffit       sit
-application/x-sv4cpio       sv4cpio
-application/x-sv4crc        sv4crc
-application/x-tar       tar
-application/x-tcl       tcl
-application/x-tex       tex
-application/x-texinfo       texinfo texi
-application/x-troff-man       man 1 2 3 4 5 6 7 8
-application/x-troff-me        me
-application/x-troff-ms        ms
-application/x-ustar       ustar
-application/x-wais-source     src
-application/x-xpinstall       xpi
-application/x-xspf+xml        xspf
-application/x-xz        xz
-audio/midi          mid midi kar
-audio/x-aiff          aif aiff aifc
-audio/x-annodex         axa
-audio/x-flac          flac
-audio/x-matroska        mka
-audio/x-mod         mod ult uni m15 mtm 669 med
-audio/x-mpegurl         m3u
-audio/x-ms-wax          wax
-audio/x-ms-wma          wma
-audio/x-pn-realaudio        ram rm
-audio/x-realaudio       ra
-audio/x-s3m         s3m
-audio/x-stm         stm
-audio/x-wav         wav
-chemical/x-xyz          xyz
-image/bmp         bmp
-image/webp          webp
-image/x-cmu-raster        ras
-image/x-portable-anymap       pnm
-image/x-portable-bitmap       pbm
-image/x-portable-graymap      pgm
-image/x-portable-pixmap       ppm
-image/x-rgb         rgb
-image/x-targa         tga
-image/x-xbitmap         xbm
-image/x-xpixmap         xpm
-image/x-xwindowdump       xwd
-text/html-sandboxed       sandboxed
-text/x-pod          pod
-text/x-setext         etx
-video/webm          webm
-video/x-annodex         axv
-video/x-flv         flv
-video/x-javafx          fxm
-video/x-matroska        mkv
-video/x-matroska-3d       mk3d
-video/x-ms-asf          asx
-video/x-ms-wm         wm
-video/x-ms-wmv          wmv
-video/x-ms-wmx          wmx
-video/x-ms-wvx          wvx
-video/x-msvideo         avi
-video/x-sgi-movie       movie
-x-conference/x-cooltalk       ice
-x-epoc/x-sisx-app       sisx
+application/vnd.oma.drm.dcf			o4a o4v
+application/vnd.oma.drm.message			dm
+application/vnd.oma.drm.rights+wbxml		drc
+application/vnd.oma.drm.rights+xml		dr
+application/vnd.sun.xml.calc			sxc
+application/vnd.sun.xml.calc.template		stc
+application/vnd.sun.xml.draw			sxd
+application/vnd.sun.xml.draw.template		std
+application/vnd.sun.xml.impress			sxi
+application/vnd.sun.xml.impress.template	sti
+application/vnd.sun.xml.math			sxm
+application/vnd.sun.xml.writer			sxw
+application/vnd.sun.xml.writer.global		sxg
+application/vnd.sun.xml.writer.template		stw
+application/vnd.symbian.install			sis
+application/vnd.wap.mms-message			mms
+application/x-annodex				anx
+application/x-bcpio				bcpio
+application/x-bittorrent			torrent
+application/x-bzip2				bz2
+application/x-cdlink				vcd
+application/x-chess-pgn				pgn
+application/x-chrome-extension			crx
+application/x-cpio				cpio
+application/x-csh				csh
+application/x-director				dcr dir dxr
+application/x-dvi				dvi
+application/x-futuresplash			spl
+application/x-gtar				gtar
+application/x-hdf				hdf
+application/x-java-archive			jar
+application/x-java-jnlp-file			jnlp
+application/x-java-pack200			pack
+application/x-killustrator			kil
+application/x-latex				latex
+application/x-netcdf				nc cdf
+application/x-perl				pl
+application/x-rpm				rpm
+application/x-sh				sh
+application/x-shar				shar
+application/x-shockwave-flash			swf
+application/x-stuffit				sit
+application/x-sv4cpio				sv4cpio
+application/x-sv4crc				sv4crc
+application/x-tar				tar
+application/x-tcl				tcl
+application/x-tex				tex
+application/x-texinfo				texinfo texi
+application/x-troff-man				man 1 2 3 4 5 6 7 8
+application/x-troff-me				me
+application/x-troff-ms				ms
+application/x-ustar				ustar
+application/x-wais-source			src
+application/x-xpinstall				xpi
+application/x-xspf+xml				xspf
+application/x-xz				xz
+audio/midi					mid midi kar
+audio/x-aiff					aif aiff aifc
+audio/x-annodex					axa
+audio/x-flac					flac
+audio/x-matroska				mka
+audio/x-mod					mod ult uni m15 mtm 669 med
+audio/x-mpegurl					m3u
+audio/x-ms-wax					wax
+audio/x-ms-wma					wma
+audio/x-pn-realaudio				ram rm
+audio/x-realaudio				ra
+audio/x-s3m					s3m
+audio/x-stm					stm
+audio/x-wav					wav
+chemical/x-xyz					xyz
+image/bmp					bmp
+image/webp					webp
+image/x-cmu-raster				ras
+image/x-portable-anymap				pnm
+image/x-portable-bitmap				pbm
+image/x-portable-graymap			pgm
+image/x-portable-pixmap				ppm
+image/x-rgb					rgb
+image/x-targa					tga
+image/x-xbitmap					xbm
+image/x-xpixmap					xpm
+image/x-xwindowdump				xwd
+text/html-sandboxed				sandboxed
+text/x-pod					pod
+text/x-setext					etx
+video/webm					webm
+video/x-annodex					axv
+video/x-flv					flv
+video/x-javafx					fxm
+video/x-matroska				mkv
+video/x-matroska-3d				mk3d
+video/x-ms-asf					asx
+video/x-ms-wm					wm
+video/x-ms-wmv					wmv
+video/x-ms-wmx					wmx
+video/x-ms-wvx					wvx
+video/x-msvideo					avi
+video/x-sgi-movie				movie
+x-conference/x-cooltalk				ice
+x-epoc/x-sisx-app				sisx


### PR DESCRIPTION
Here are the non-aesthetic modifications I made in my version, presented for selection.

- [ ] [I updated the `mime.types` file.](https://github.com/elixir-lang/mime/commit/be88bd0e713e80dbf35e5063049393455d9c60e2)
    It's mostly whitespace noise in the change but there's several additions and a couple of deletions.
    I also jotted down the last updated time for future reference.

- [ ] [I made the extra types configuration a little more helpful.](https://github.com/elixir-lang/mime/commit/23932aaf3295daf780f4d39f95904ca3f91b9f17)
    Previously one could enter any data structure that enumerates as a two-tuple and it would get added to the registry verbatim, and not always in a valid fashion.
    Now the mime types and extensions are coerced into strings and will raise a compile time error if they can't be. Additionally, the extensions are wrapped in a list if they weren't already.
    I've left the documentation as-is to provide visibility into the desired data structure, but this prevents subtle issues if, for instance, one does `config :mime, :types, valid_type: :and_extension`, and will raise `protocol String.Chars not implemented` on `config :mime, :types, %{self => [make_ref]}` instead of accepting it.
    An alternative would be to simply raise if `@type [{String.t, [String.t]}]` isn't supplied.

- [ ] ~~[I've soft-deprecated the old configuration.](https://github.com/elixir-lang/mime/commit/2d80bd68bafb1642c32c7292d8bd1cb95fe22d82)
    If detected, it will use the old `config :plug, :mimes`, issue a deprecation warning, and then merge in the new `config :mime, :types`.
    This will probably prevent a lot of people from missing this in the release notes and breaking their Phoenix APIs.
    It also avoids semver questions of whether or not Plug and Phoenix should do a major bump for this change alone.~~

- [ ] [I've added access to the full mapping registry.](https://github.com/elixir-lang/mime/commit/eb2c575f740a6690ade37d09d80720bb38324d43)
    If people really want to do `if "foo" in MIME.types, do: IO.puts "found"`, they can. This could be handy because `MIME.extension/1` returns a default if not found, so you can't explicitly check if a string is a MIME type.
    This also allows for the related `if "bar" in MIME.extensions, do: IO.puts "found"`, of which there is no direct analog and `if {"foo", ["bar", "baz"]} in MIME.mapping, do: IO.puts "found"` if you really wanna match on something.
    This comes with a compile-time and compile-size penalty which I've made some notes on in the commit.
    An alternative approach could macro-ize generation of several predicate functions for these but I suspect the time and size penalties would be similar; and while runtime inclusion checking would be faster, you still couldn't introspect on all the options available. Doing both would be optimal from a runtime speed and rich API perspective but double the compile-time penalties.
    Seeing as this library will launch immediately with [![Hex.pm](https://img.shields.io/hexpm/dd/plug.svg?maxAge=2592000?style=flat-square)]() alongside Plug, it's worth considering the implications of these trade-offs of API-robustness for optimized common-path speed.

- [ ] [I customized the default README a little more.](https://github.com/elixir-lang/mime/commit/9b01b2d07af7051ec2728c415bb7969e587a4669)

Outside of simple stylistic differences, the other things I did involved setting up travis, exdoc, github pages, and shield.io badges; but that was mostly out of personal interest in learning how to instrument those things in elixir and hex. They can be viewed at [the source](https://github.com/christhekeele/elixir-mime/tree/development) or browsed from [the hex links](https://hex.pm/packages/mime_types) but are pretty incidental.

Never used github checkboxes before, but if they work the way I think they do, you should be able to just check off any of these commits and I'll rebase out the others; just let me know if you want any of the extra instrumentation.