### PR TITLE
Configure docs to use MIME as the main module

### DIFF
--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -9,7 +9,7 @@ defmodule MIME do
         "application/vnd.api+json" => ["json-api"]
       }
 
-  After adding the configuration, Mime needs to be recompiled.
+  After adding the configuration, MIME needs to be recompiled.
   If you are using mix, it can be done with:
 
       $ mix deps.clean mime --build

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule MIME.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      deps: deps,
-     docs: [source_ref: "v#{@version}",
+     docs: [source_ref: "v#{@version}", main: "MIME",
             source_url: "https://github.com/elixir-lang/mime"]]
   end
 


### PR DESCRIPTION
This way <https://hexdocs.pm/mime> will immedietaly redirect to
<https://hexdocs.pm/mime/MIME.html>