### PR TITLE
Add json-api extension

### DIFF
--- a/lib/mime.types
+++ b/lib/mime.types
@@ -389,7 +389,7 @@ application/vnd.antix.game-component
 application/vnd.apache.thrift.binary
 application/vnd.apache.thrift.compact
 application/vnd.apache.thrift.json
-application/vnd.api+json
+application/vnd.api+json    json-api
 application/vnd.apple.installer+xml		dist distz pkg mpkg
 # m3u: audio/x-mpegurl for now
 application/vnd.apple.mpegurl			m3u8

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.5"}}
+%{"earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -11,7 +11,7 @@ defmodule MIMETest do
 
   test "extensions/1" do
     assert "json" in extensions("application/json")
-    assert extensions("application/vnd.api+json") == []
+    assert extensions("application/vnd.api+json") == ["json-api"]
   end
 
   test "type/1" do


### PR DESCRIPTION
json-api is a format growing in popularity. The README does mention a way to add this in but I think it makes more sense to have this in by default