### PR TITLE
Test on Elixir 1.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,16 @@
 language: elixir
-elixir:
-  - 1.0.5
-  - 1.1.1
-  - 1.2.0
 sudo: false
+elixir: 1.4.0
+otp_release: 19.1
+matrix:
+  include:
+    - otp_release: 17.5
+      elixir: 1.0.5
 notifications:
   recipients:
     - jose.valim@plataformatec.com.br
-otp_release:
-  - 17.5
-  - 18.1
 env:
   - MIX_ENV=test
 # after_script:
 #   - mix deps.get --only docs
 #   - MIX_ENV=docs mix inch.report
-matrix:
-  exclude:
-    - otp_release: 17.5
-      elixir: 1.2.0


### PR DESCRIPTION
I also updated the .travis.yml to match elixir-lang/ex_doc#656 so that only the newest and oldest Elixir/OTP pairs are tested.