### PR TITLE
Add function for determining existence of type

### DIFF
--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -99,6 +99,31 @@ defmodule MIME do
   def type(_ext), do: @default_type
 
   @doc """
+  Returns whether an extension has a MIME type registered.
+
+  ## Examples
+
+      iex> MIME.type_known?("txt")
+      true
+
+      iex> MIME.type_known?("foobarbaz")
+      false
+
+  """
+  @spec type_known?(String.t) :: boolean
+  def type_known?(file_extension)
+
+  for {_type, exts} <- app, ext <- List.wrap(exts) do
+    def type_known?(unquote(ext)), do: true
+  end
+
+  for {_type, exts} <- mapping, ext <- exts do
+    def type_known?(unquote(ext)), do: true
+  end
+
+  def type_known?(_ext), do: false
+
+  @doc """
   Guesses the MIME type based on the path's extension. See `type/1`.
 
   ## Examples

--- a/test/mime_test.exs
+++ b/test/mime_test.exs
@@ -19,6 +19,11 @@ defmodule MIMETest do
     assert type("foo") == "application/octet-stream"
   end
 
+  test "type_known?/1" do
+    assert type_known?("json") == true
+    assert type_known?("foo") == false
+  end
+
   test "from_path/1" do
     assert from_path("index.html") == "text/html"
     assert from_path("index.HTML") == "text/html"


### PR DESCRIPTION
Noticed there was no way to check for extension existence in the mime map. This is needed because it's not clear if `application/octet-stream` is real or faked :)