### PR TITLE
Sync with IANA as of 2017-03-12

### DIFF
--- a/lib/mime.types
+++ b/lib/mime.types
@@ -1,8 +1,8 @@
-# https://git.fedorahosted.org/cgit/mailcap.git/plain/mime.types
+# https://pagure.io/mailcap/blob/master/f/mime.types
 
-# Updated:                2016-04-28
-# Synced with IANA as of: 2016-04-17
-# Reference: https://git.fedorahosted.org/cgit/mailcap.git/commit/?id=c038c01832de3ea44945a2b26137313fd6263a77
+# Updated:                2017-03-12
+# Synced with IANA as of: 2017-03-12
+# Reference: https://pagure.io/mailcap.git/
 
 # This file controls what Internet media types are sent to the client for
 # given file extension(s).  Sending the correct media type to the client
@@ -49,7 +49,8 @@ application/calendar+json
 application/calendar+xml			xcs
 application/call-completion
 application/cals-1840
-application/cbor				cbor
+# cbor: application/cose
+application/cbor
 application/ccmp+xml				ccmp
 application/ccxml+xml				ccxml
 application/CDFX+XML				cdfx
@@ -67,9 +68,15 @@ application/clue_info+xml			clue
 application/cms					cmsc
 application/cnrp+xml
 application/coap-group+json
+application/coap-payload
 application/commonground
 application/conference-info+xml
 application/cpl+xml				cpl
+application/cose				cbor
+# cbor: application/cose
+application/cose-key
+# cbor: application/cose
+application/cose-key-set
 application/csrattrs				csrattrs
 application/csta+xml
 application/CSTAdata+xml
@@ -83,6 +90,8 @@ application/DCD					dcd
 application/dec-dx
 application/dialog-info+xml
 application/dicom				dcm
+application/dicom+json
+application/dicom+xml
 application/DII					dii
 application/DIT					dit
 application/dns
@@ -96,10 +105,13 @@ application/EDI-X12
 application/EDIFACT
 application/efi					efi
 application/EmergencyCallData.Comment+xml
+application/EmergencyCallData.Control+xml
 application/EmergencyCallData.DeviceInfo+xml
+application/EmergencyCallData.eCall.MSD
 application/EmergencyCallData.ProviderInfo+xml
 application/EmergencyCallData.ServiceInfo+xml
 application/EmergencyCallData.SubscriberInfo+xml
+application/EmergencyCallData.VEDS+xml
 application/emma+xml				emma
 application/emotionml+xml			emotionml
 application/encaprtp
@@ -112,11 +124,13 @@ application/fastsoap
 application/fdt+xml				fdt
 # fits, fit, fts: image/fits
 application/fits
-application/font-sfnt				ttf
+# application/font-sfnt deprecated in favor of font/sfnt
 application/font-tdpfr				pfr
-application/font-woff				woff
+# application/font-woff deprecated in favor of font/woff
 application/framework-attributes+xml
 application/geo+json				geojson
+application/geo+json-seq
+application/gml+xml				gml
 application/gzip				gz tgz
 application/H224
 application/held+xml
@@ -204,7 +218,10 @@ application/mrb-publish+xml
 application/msc-ivr+xml
 application/msc-mixer+xml
 application/msword				doc
+application/mud+json
 application/mxf					mxf
+application/n-quads				nq
+application/n-triples				nt
 application/nasdata
 application/news-checkgroups
 application/news-groupinfo
@@ -334,6 +351,7 @@ application/thraud+xml				tfi
 application/timestamp-query			tsq
 application/timestamp-reply			tsr
 application/timestamped-data			tsd
+application/trig				trig
 application/ttml+xml				ttml
 application/tve-trigger
 application/ulpfec
@@ -368,8 +386,7 @@ application/vnd.accpac.simply.aso		aso
 application/vnd.accpac.simply.imp		imp
 application/vnd.acucobol			acu
 application/vnd.acucorp				atc acutc
-# swf: application/x-shockwave-flash for now
-application/vnd.adobe.flash.movie
+application/vnd.adobe.flash.movie		swf
 application/vnd.adobe.formscentral.fcdt		fcdt
 application/vnd.adobe.fxp			fxp fxpl
 application/vnd.adobe.partial-upload
@@ -393,7 +410,8 @@ application/vnd.antix.game-component
 application/vnd.apache.thrift.binary
 application/vnd.apache.thrift.compact
 application/vnd.apache.thrift.json
-application/vnd.api+json    json-api
+application/vnd.api+json
+application/vnd.apothekende.reservation+json
 application/vnd.apple.installer+xml		dist distz pkg mpkg
 # m3u: audio/x-mpegurl for now
 application/vnd.apple.mpegurl			m3u8
@@ -456,8 +474,10 @@ application/vnd.cups-raw
 application/vnd.curl				curl
 application/vnd.cyan.dean.root+xml
 application/vnd.cybank
+application/vnd.d2l.coursepackage1p0+zip
 application/vnd.dart				dart
 application/vnd.data-vision.rdz			rdz
+application/vnd.dataresource+json
 application/vnd.debian.binary-package		deb udeb
 application/vnd.dece.data			uvf uvvf uvd uvvd
 application/vnd.dece.ttml+xml			uvt uvvt
@@ -511,6 +531,10 @@ application/vnd.ecowin.fileupdate
 application/vnd.ecowin.series
 application/vnd.ecowin.seriesrequest
 application/vnd.ecowin.seriesupdate
+# img: application/octet-stream
+application/vnd.efi-img
+# iso: application/octet-stream
+application/vnd.efi-iso
 application/vnd.enliven				nml
 application/vnd.enphase.envoy
 application/vnd.eprints.data+xml
@@ -611,6 +635,7 @@ application/vnd.hal+json
 application/vnd.hal+xml				hal
 application/vnd.HandHeld-Entertainment+xml	zmm
 application/vnd.hbci				hbci hbc kom upa pkd bpd
+application/vnd.hc+json
 # rep: application/vnd.businessobjects
 application/vnd.hcl-bireports
 application/vnd.hdt				hdt
@@ -635,6 +660,7 @@ application/vnd.ibm.secure-container		sc
 application/vnd.iccprofile			icc icm
 application/vnd.ieee.1905			1905.1
 application/vnd.igloader			igl
+application/vnd.imagemeter.image+zip		imi
 application/vnd.immervision-ivp			ivp
 application/vnd.immervision-ivu			ivu
 application/vnd.ims.imsccv1p1			imscc
@@ -696,6 +722,7 @@ application/vnd.kidspiration			kia
 application/vnd.Kinar				kne knp sdf
 application/vnd.koan				skp skd skm skt
 application/vnd.kodak-descriptor		sse
+application/vnd.las.las+json			lasjson
 application/vnd.las.las+xml			lasxml
 application/vnd.liberty-request+xml
 application/vnd.llamagraphics.life-balance.desktop	lbd
@@ -836,7 +863,8 @@ application/vnd.oasis.opendocument.chart			odc
 application/vnd.oasis.opendocument.chart-template		otc
 application/vnd.oasis.opendocument.database			odb
 application/vnd.oasis.opendocument.formula			odf
-application/vnd.oasis.opendocument.formula-template		otf
+# otf: font/otf
+application/vnd.oasis.opendocument.formula-template
 application/vnd.oasis.opendocument.graphics			odg
 application/vnd.oasis.opendocument.graphics-template		otg
 application/vnd.oasis.opendocument.image			odi
@@ -850,6 +878,7 @@ application/vnd.oasis.opendocument.text-master			odm
 application/vnd.oasis.opendocument.text-template		ott
 application/vnd.oasis.opendocument.text-web			oth
 application/vnd.obn
+application/vnd.ocf+cbor
 application/vnd.oftn.l10n+json
 application/vnd.oipf.contentaccessdownload+xml
 application/vnd.oipf.contentaccessstreaming+xml
@@ -908,6 +937,7 @@ application/vnd.openblox.game+xml		obgx
 application/vnd.openblox.game-binary		obg
 application/vnd.openeye.oeb			oeb
 application/vnd.openofficeorg.extension		oxt
+application/vnd.openstreetmap.data+xml		osm
 application/vnd.openxmlformats-officedocument.custom-properties+xml
 application/vnd.openxmlformats-officedocument.customXmlProperties+xml
 application/vnd.openxmlformats-officedocument.drawing+xml
@@ -1105,12 +1135,14 @@ application/vnd.syncml.dmddf+xml		ddf
 application/vnd.syncml.dmtnds+wbxml
 application/vnd.syncml.dmtnds+xml
 application/vnd.syncml.ds.notification
+application/vnd.tableschema+json
 application/vnd.tao.intent-module-archive	tao
 application/vnd.tcpdump.pcap			pcap cap dmp
 application/vnd.theqvd				qvd
 application/vnd.tmd.mediaflex.api+xml
 application/vnd.tml				vfr viaframe
 application/vnd.tmobile-livetv			tmo
+application/vnd.tri.onesource
 application/vnd.trid.tpt			tpt
 application/vnd.triscape.mxs			mxs
 application/vnd.trueapp				tra
@@ -1233,6 +1265,10 @@ application/xop+xml				xop
 application/xslt+xml				xsl xslt
 application/xv+xml				mxml xhvml xvml xvm
 application/yang				yang
+application/yang-data+json
+application/yang-data+xml
+application/yang-patch+json
+application/yang-patch+xml
 application/yin+xml				yin
 application/zip					zip
 application/zlib
@@ -1310,6 +1346,10 @@ audio/L20
 audio/L24
 audio/L8
 audio/LPC
+audio/MELP
+audio/MELP600
+audio/MELP1200
+audio/MELP2400
 audio/mobile-xmf				mxmf
 # mp4, mpg4: video/mp4, see RFC 4337
 audio/mp4					m4a
@@ -1392,6 +1432,12 @@ audio/vnd.sealedmedia.softseal.mpeg		smp3 smp s1m
 audio/vnd.vmx.cvsd
 audio/vorbis
 audio/vorbis-config
+font/collection					ttc
+font/otf					otf
+font/sfnt
+font/ttf					ttf
+font/woff					woff
+font/woff2					woff2
 image/bmp					bmp dib
 image/cgm					cgm
 image/dicom-rle					drle
@@ -1715,7 +1761,6 @@ application/x-perl				pl
 application/x-rpm				rpm
 application/x-sh				sh
 application/x-shar				shar
-application/x-shockwave-flash			swf
 application/x-stuffit				sit
 application/x-sv4cpio				sv4cpio
 application/x-sv4crc				sv4crc


### PR DESCRIPTION
- Fedorahosted got [retired](https://fedoraproject.org/wiki/Infrastructure/Fedorahosted-retirement), and mailcap is now at [Pagure](https://pagure.io/mailcap).

- Just copied the latest version of mime.types from that repo. The diff is quite big, not sure we'd want to merge all of it. It breaks the test `extensions("application/vnd.api+json") == ["json-api"]`, for instance (`test/mime_test.exs:14`)