### PR TITLE
ft: add MIME type for JPEG XL images

### DIFF
--- a/lib/mime.ex
+++ b/lib/mime.ex
@@ -83,6 +83,7 @@ defmodule MIME do
     "image/bmp" => ["bmp"],
     "image/gif" => ["gif"],
     "image/jpeg" => ["jpg", "jpeg"],
+    "image/jxl" => ["jxl"],
     "image/png" => ["png"],
     "image/svg+xml" => ["svg", "svgz"],
     "image/tiff" => ["tiff", "tif"],


### PR DESCRIPTION
Adds the MIME type for JPEG XL images, which will soon be available in browsers. 

https://jpegxl.info/
https://caniuse.com/jpegxl